### PR TITLE
feat(game): add validated state machine and tests

### DIFF
--- a/src/lib/game/schema.ts
+++ b/src/lib/game/schema.ts
@@ -1,0 +1,322 @@
+import { z } from "zod";
+
+import {
+  type Action,
+  type Card,
+  type FinishedState,
+  GameConclusionReason,
+  type GameState,
+  GameStatus,
+  type Grid,
+  type GuessResult,
+  type IdleState,
+  type LobbyState,
+  type Message,
+  type Player,
+  type PlayerIdentity,
+  PlayerRole,
+  type PlayingState,
+} from "./types";
+
+/**
+ * Runtime schemas used to validate any data coming from the network or storage.
+ */
+export const cardSchema: z.ZodType<Card> = z
+  .object({
+    id: z.string().min(1, "Card identifier is required"),
+    label: z.string().min(1, "Card label is required"),
+    imageUrl: z.string().url().optional(),
+    description: z.string().max(280).optional(),
+  })
+  .strict();
+
+export const gridSchema: z.ZodType<Grid> = z
+  .object({
+    id: z.string().min(1, "Grid identifier is required"),
+    name: z.string().min(1, "Grid name is required"),
+    rows: z.number().int().positive(),
+    columns: z.number().int().positive(),
+    cards: z.array(cardSchema).min(1, "A grid requires at least one card"),
+  })
+  .strict()
+  .superRefine((grid, ctx) => {
+    const capacity = grid.rows * grid.columns;
+    if (grid.cards.length > capacity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Grid capacity cannot be smaller than the number of cards",
+        path: ["cards"],
+      });
+    }
+    const uniqueIds = new Set(grid.cards.map((card) => card.id));
+    if (uniqueIds.size !== grid.cards.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Card identifiers must be unique within the grid",
+        path: ["cards"],
+      });
+    }
+  });
+
+export const playerRoleSchema = z.nativeEnum(PlayerRole);
+
+export const playerIdentitySchema: z.ZodType<PlayerIdentity> = z
+  .object({
+    id: z.string().min(1, "Player identifier is required"),
+    name: z.string().min(1, "Player name is required"),
+    role: playerRoleSchema.optional(),
+  })
+  .strict();
+
+export const playerSchema: z.ZodType<Player> = z
+  .object({
+    id: z.string().min(1, "Player identifier is required"),
+    name: z.string().min(1, "Player name is required"),
+    role: playerRoleSchema,
+    secretCardId: z.string().optional(),
+    flippedCardIds: z
+      .array(z.string().min(1))
+      .default([])
+      .superRefine((ids, ctx) => {
+        const unique = new Set(ids);
+        if (unique.size !== ids.length) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Flipped card identifiers must be unique",
+            path: ["flippedCardIds"],
+          });
+        }
+      }),
+  })
+  .strict();
+
+export const guessResultSchema: z.ZodType<GuessResult> = z
+  .object({
+    guesserId: z.string().min(1),
+    targetPlayerId: z.string().min(1),
+    cardId: z.string().min(1),
+    correct: z.boolean(),
+  })
+  .strict();
+
+const idleStateSchemaInternal: z.ZodType<IdleState> = z
+  .object({
+    status: z.literal(GameStatus.Idle),
+    players: z.array(playerSchema).length(0),
+  })
+  .strict();
+
+const lobbyStateSchemaInternal: z.ZodType<LobbyState> = z
+  .object({
+    status: z.literal(GameStatus.Lobby),
+    hostId: z.string().min(1),
+    grid: gridSchema,
+    players: z.array(playerSchema).min(1).max(2),
+  })
+  .strict()
+  .superRefine((state, ctx) => {
+    if (!state.players.some((player) => player.id === state.hostId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Host player must be present in the lobby",
+        path: ["hostId"],
+      });
+    }
+  });
+
+const playingStateSchemaInternal: z.ZodType<PlayingState> = z
+  .object({
+    status: z.literal(GameStatus.Playing),
+    hostId: z.string().min(1),
+    grid: gridSchema,
+    players: z.array(playerSchema).length(2),
+    activePlayerId: z.string().min(1),
+    turn: z.number().int().positive(),
+  })
+  .strict()
+  .superRefine((state, ctx) => {
+    if (!state.players.some((player) => player.id === state.hostId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Host player must be part of the match",
+        path: ["hostId"],
+      });
+    }
+    if (!state.players.some((player) => player.id === state.activePlayerId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Active player must be one of the players in the match",
+        path: ["activePlayerId"],
+      });
+    }
+  });
+
+const finishedStateSchemaInternal: z.ZodType<FinishedState> = z
+  .object({
+    status: z.literal(GameStatus.Finished),
+    hostId: z.string().min(1),
+    grid: gridSchema,
+    players: z.array(playerSchema).length(2),
+    turn: z.number().int().positive(),
+    winnerId: z.string().min(1),
+    reason: z.nativeEnum(GameConclusionReason),
+    finalGuess: guessResultSchema,
+  })
+  .strict()
+  .superRefine((state, ctx) => {
+    if (!state.players.some((player) => player.id === state.winnerId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Winner must be included in the final player list",
+        path: ["winnerId"],
+      });
+    }
+    if (
+      !state.players.some(
+        (player) => player.id === state.finalGuess.targetPlayerId,
+      )
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Final guess must target a player from the match",
+        path: ["finalGuess", "targetPlayerId"],
+      });
+    }
+    if (
+      !state.players.some((player) => player.id === state.finalGuess.guesserId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Final guess must originate from a player in the match",
+        path: ["finalGuess", "guesserId"],
+      });
+    }
+  });
+
+export const gameStateSchema: z.ZodType<GameState> = z.discriminatedUnion(
+  "status",
+  [
+    idleStateSchemaInternal,
+    lobbyStateSchemaInternal,
+    playingStateSchemaInternal,
+    finishedStateSchemaInternal,
+  ],
+);
+
+export const createLobbyActionSchema = z
+  .object({
+    type: z.literal<"game/createLobby">("game/createLobby"),
+    payload: z.object({
+      grid: gridSchema,
+      host: playerIdentitySchema,
+    }),
+  })
+  .strict();
+
+export const joinLobbyActionSchema = z
+  .object({
+    type: z.literal<"game/joinLobby">("game/joinLobby"),
+    payload: z.object({
+      player: playerIdentitySchema,
+    }),
+  })
+  .strict();
+
+export const setSecretActionSchema = z
+  .object({
+    type: z.literal<"game/setSecret">("game/setSecret"),
+    payload: z.object({
+      playerId: z.string().min(1),
+      cardId: z.string().min(1),
+    }),
+  })
+  .strict();
+
+export const startGameActionSchema = z
+  .object({
+    type: z.literal<"game/start">("game/start"),
+    payload: z.object({
+      startingPlayerId: z.string().min(1).optional(),
+    }),
+  })
+  .strict();
+
+export const flipCardActionSchema = z
+  .object({
+    type: z.literal<"turn/flipCard">("turn/flipCard"),
+    payload: z.object({
+      playerId: z.string().min(1),
+      cardId: z.string().min(1),
+    }),
+  })
+  .strict();
+
+export const endTurnActionSchema = z
+  .object({
+    type: z.literal<"turn/end">("turn/end"),
+    payload: z.object({
+      playerId: z.string().min(1),
+    }),
+  })
+  .strict();
+
+export const guessActionSchema = z
+  .object({
+    type: z.literal<"turn/guess">("turn/guess"),
+    payload: z.object({
+      playerId: z.string().min(1),
+      targetPlayerId: z.string().min(1),
+      cardId: z.string().min(1),
+    }),
+  })
+  .strict();
+
+export const resetActionSchema = z
+  .object({
+    type: z.literal<"game/reset">("game/reset"),
+  })
+  .strict();
+
+export const actionSchema: z.ZodType<Action> = z.discriminatedUnion("type", [
+  createLobbyActionSchema,
+  joinLobbyActionSchema,
+  setSecretActionSchema,
+  startGameActionSchema,
+  flipCardActionSchema,
+  endTurnActionSchema,
+  guessActionSchema,
+  resetActionSchema,
+]);
+
+export const messageSchema: z.ZodType<Message> = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal<"game/snapshot">("game/snapshot"),
+      state: gameStateSchema,
+      issuedAt: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal<"game/action">("game/action"),
+      action: actionSchema,
+      issuerId: z.string().min(1),
+      issuedAt: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal<"game/error">("game/error"),
+      code: z.string().min(1),
+      message: z.string().min(1),
+      issuedAt: z.number().int().nonnegative(),
+    })
+    .strict(),
+]);
+
+export type CardSchema = typeof cardSchema;
+export type GridSchema = typeof gridSchema;
+export type PlayerSchema = typeof playerSchema;
+export type GameStateSchema = typeof gameStateSchema;
+export type ActionSchema = typeof actionSchema;
+export type MessageSchema = typeof messageSchema;

--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  canStartGame,
+  createInitialState,
+  InvalidGameActionError,
+  isPlayerReady,
+  reduceGameState,
+  selectActivePlayer,
+  selectPlayerById,
+  selectWinner,
+} from "./state";
+import {
+  GameConclusionReason,
+  type GameState,
+  GameStatus,
+  type Grid,
+  PlayerRole,
+  type PlayingState,
+} from "./types";
+
+const createGrid = (): Grid => ({
+  id: "grid-1",
+  name: "Test Grid",
+  rows: 2,
+  columns: 2,
+  cards: [
+    { id: "card-a", label: "Alpha" },
+    { id: "card-b", label: "Beta" },
+    { id: "card-c", label: "Gamma" },
+    { id: "card-d", label: "Delta" },
+  ],
+});
+
+const hostId = "player-host";
+const guestId = "player-guest";
+
+const createLobbyState = (): GameState => {
+  const initial = createInitialState();
+  const afterCreate = reduceGameState(initial, {
+    type: "game/createLobby",
+    payload: {
+      grid: createGrid(),
+      host: { id: hostId, name: "Host", role: PlayerRole.Host },
+    },
+  });
+
+  return reduceGameState(afterCreate, {
+    type: "game/joinLobby",
+    payload: {
+      player: { id: guestId, name: "Guest", role: PlayerRole.Guest },
+    },
+  });
+};
+
+const asPlayingState = (state: GameState): PlayingState => {
+  if (state.status !== GameStatus.Playing) {
+    throw new Error("Expected playing state");
+  }
+  return state;
+};
+
+const createPlayingState = (): PlayingState => {
+  const lobby = createLobbyState();
+  const withHostSecret = reduceGameState(lobby, {
+    type: "game/setSecret",
+    payload: { playerId: hostId, cardId: "card-a" },
+  });
+  const withGuestSecret = reduceGameState(withHostSecret, {
+    type: "game/setSecret",
+    payload: { playerId: guestId, cardId: "card-d" },
+  });
+  expect(canStartGame(withGuestSecret)).toBe(true);
+  const started = reduceGameState(withGuestSecret, {
+    type: "game/start",
+    payload: { startingPlayerId: hostId },
+  });
+  return asPlayingState(started);
+};
+
+describe("reduceGameState", () => {
+  it("creates a lobby from the idle state", () => {
+    const initial = createInitialState();
+    const lobby = reduceGameState(initial, {
+      type: "game/createLobby",
+      payload: { grid: createGrid(), host: { id: hostId, name: "Host" } },
+    });
+
+    expect(lobby.status).toBe(GameStatus.Lobby);
+    expect(lobby.players).toHaveLength(1);
+    expect(lobby.players[0]).toMatchObject({
+      id: hostId,
+      role: PlayerRole.Host,
+    });
+  });
+
+  it("prevents joining a lobby more than once per player", () => {
+    const lobby = createLobbyState();
+    expect(() =>
+      reduceGameState(lobby, {
+        type: "game/joinLobby",
+        payload: { player: { id: guestId, name: "Guest Again" } },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("rejects more than two players in a lobby", () => {
+    const lobby = createLobbyState();
+    expect(() =>
+      reduceGameState(lobby, {
+        type: "game/joinLobby",
+        payload: { player: { id: "third", name: "Third Player" } },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("enforces secret selection before starting the game", () => {
+    const lobby = createLobbyState();
+    const withHostSecret = reduceGameState(lobby, {
+      type: "game/setSecret",
+      payload: { playerId: hostId, cardId: "card-a" },
+    });
+
+    expect(() =>
+      reduceGameState(withHostSecret, {
+        type: "game/start",
+        payload: { startingPlayerId: hostId },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("allows updating a secret and remains idempotent when unchanged", () => {
+    const lobby = createLobbyState();
+    const updated = reduceGameState(lobby, {
+      type: "game/setSecret",
+      payload: { playerId: hostId, cardId: "card-a" },
+    });
+    const same = reduceGameState(updated, {
+      type: "game/setSecret",
+      payload: { playerId: hostId, cardId: "card-a" },
+    });
+
+    expect(same).toBe(updated);
+    expect(isPlayerReady(updated, hostId)).toBe(true);
+  });
+
+  it("rejects selecting a secret that is not part of the grid", () => {
+    const lobby = createLobbyState();
+    expect(() =>
+      reduceGameState(lobby, {
+        type: "game/setSecret",
+        payload: { playerId: hostId, cardId: "unknown" },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("starts the game once both players are ready", () => {
+    const playing = createPlayingState();
+
+    expect(playing.status).toBe(GameStatus.Playing);
+    expect(playing.activePlayerId).toBe(hostId);
+    expect(playing.turn).toBe(1);
+    expect(selectActivePlayer(playing)?.id).toBe(hostId);
+  });
+
+  it("prevents flipping cards when not the active player", () => {
+    const playing = createPlayingState();
+
+    expect(() =>
+      reduceGameState(playing, {
+        type: "turn/flipCard",
+        payload: { playerId: guestId, cardId: "card-b" },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("prevents flipping the secret card", () => {
+    const playing = createPlayingState();
+
+    expect(() =>
+      reduceGameState(playing, {
+        type: "turn/flipCard",
+        payload: { playerId: hostId, cardId: "card-a" },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("flips cards deterministically and is idempotent", () => {
+    const playing = createPlayingState();
+    const action = {
+      type: "turn/flipCard" as const,
+      payload: { playerId: hostId, cardId: "card-b" },
+    };
+    const afterFirstFlip = reduceGameState(playing, action);
+    const afterSecondFlip = reduceGameState(afterFirstFlip, action);
+
+    const activePlayer = selectActivePlayer(afterFirstFlip);
+    expect(activePlayer?.flippedCardIds).toEqual(["card-b"]);
+    expect(afterSecondFlip).toBe(afterFirstFlip);
+  });
+
+  it("changes the active player when ending a turn", () => {
+    const playing = createPlayingState();
+    const afterEndTurn = reduceGameState(playing, {
+      type: "turn/end",
+      payload: { playerId: hostId },
+    });
+
+    expect(afterEndTurn.status).toBe(GameStatus.Playing);
+    expect(asPlayingState(afterEndTurn).activePlayerId).toBe(guestId);
+    expect(asPlayingState(afterEndTurn).turn).toBe(2);
+  });
+
+  it("does not allow ending the turn out of turn order", () => {
+    const playing = createPlayingState();
+
+    expect(() =>
+      reduceGameState(playing, {
+        type: "turn/end",
+        payload: { playerId: guestId },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("wins the match on a correct guess", () => {
+    const playing = createPlayingState();
+    const finished = reduceGameState(playing, {
+      type: "turn/guess",
+      payload: { playerId: hostId, targetPlayerId: guestId, cardId: "card-d" },
+    });
+
+    expect(finished.status).toBe(GameStatus.Finished);
+    expect(finished.winnerId).toBe(hostId);
+    expect(finished.reason).toBe(GameConclusionReason.CorrectGuess);
+    expect(finished.finalGuess).toMatchObject({ correct: true });
+    expect(selectWinner(finished)?.id).toBe(hostId);
+  });
+
+  it("declares the opponent as winner on an incorrect guess", () => {
+    const playing = createPlayingState();
+    const finished = reduceGameState(playing, {
+      type: "turn/guess",
+      payload: { playerId: hostId, targetPlayerId: guestId, cardId: "card-b" },
+    });
+
+    expect(finished.status).toBe(GameStatus.Finished);
+    expect(finished.winnerId).toBe(guestId);
+    expect(finished.reason).toBe(GameConclusionReason.IncorrectGuess);
+    expect(finished.finalGuess).toMatchObject({
+      correct: false,
+      cardId: "card-b",
+    });
+  });
+
+  it("prevents guessing outside of a turn", () => {
+    const playing = createPlayingState();
+
+    expect(() =>
+      reduceGameState(playing, {
+        type: "turn/guess",
+        payload: {
+          playerId: guestId,
+          targetPlayerId: hostId,
+          cardId: "card-a",
+        },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
+  it("resets back to the idle state", () => {
+    const playing = createPlayingState();
+    const finished = reduceGameState(playing, {
+      type: "turn/guess",
+      payload: { playerId: hostId, targetPlayerId: guestId, cardId: "card-d" },
+    });
+
+    const reset = reduceGameState(finished, { type: "game/reset" });
+    expect(reset.status).toBe(GameStatus.Idle);
+    expect(reset.players).toEqual([]);
+  });
+});
+
+describe("selectors", () => {
+  it("returns players and readiness flags", () => {
+    const lobby = createLobbyState();
+    expect(selectPlayerById(lobby, hostId)?.role).toBe(PlayerRole.Host);
+    expect(isPlayerReady(lobby, hostId)).toBe(false);
+
+    const updated = reduceGameState(lobby, {
+      type: "game/setSecret",
+      payload: { playerId: hostId, cardId: "card-a" },
+    });
+
+    expect(isPlayerReady(updated, hostId)).toBe(true);
+  });
+
+  it("provides the active player only while playing", () => {
+    const idle = createInitialState();
+    expect(selectActivePlayer(idle)).toBeUndefined();
+
+    const playing = createPlayingState();
+    expect(selectActivePlayer(playing)?.id).toBe(hostId);
+  });
+});

--- a/src/lib/game/state.ts
+++ b/src/lib/game/state.ts
@@ -1,0 +1,458 @@
+import {
+  actionSchema,
+  cardSchema,
+  gridSchema,
+  playerIdentitySchema,
+  playerSchema,
+} from "./schema";
+import {
+  type Action,
+  type FinishedState,
+  GameConclusionReason,
+  type GameState,
+  GameStatus,
+  type Grid,
+  type GuessResult,
+  type IdleState,
+  type LobbyState,
+  type Player,
+  type PlayerIdentity,
+  type PlayingState,
+} from "./types";
+
+/**
+ * Error thrown when an action cannot be applied on the provided state.
+ */
+export class InvalidGameActionError extends Error {
+  readonly action: Action;
+
+  constructor(action: Action, message: string) {
+    super(message);
+    this.name = "InvalidGameActionError";
+    this.action = action;
+  }
+}
+
+export const createInitialState = (): IdleState => ({
+  status: GameStatus.Idle,
+  players: [],
+});
+
+const assert = (condition: unknown, action: Action, message: string): void => {
+  if (!condition) {
+    throw new InvalidGameActionError(action, message);
+  }
+};
+
+const expectState = <TStatus extends GameState["status"]>(
+  state: GameState,
+  status: TStatus,
+  action: Action,
+): Extract<GameState, { status: TStatus }> => {
+  assert(
+    state.status === status,
+    action,
+    `Expected state "${status}" but received "${state.status}"`,
+  );
+  return state as Extract<GameState, { status: TStatus }>;
+};
+
+const ensureCardBelongsToGrid = (
+  grid: Grid,
+  cardId: string,
+  action: Action,
+): void => {
+  const found = grid.cards.some((card) => card.id === cardId);
+  assert(found, action, `Card "${cardId}" does not exist in the current grid`);
+};
+
+const normalisePlayer = (candidate: Player): Player => {
+  const parsed = playerSchema.parse(candidate);
+  return {
+    ...parsed,
+    flippedCardIds: [...parsed.flippedCardIds],
+  };
+};
+
+const createPlayer = (
+  identity: PlayerIdentity,
+  role: Player["role"],
+): Player => {
+  const parsedIdentity = playerIdentitySchema.parse(identity);
+  const playerCandidate: Player = {
+    id: parsedIdentity.id,
+    name: parsedIdentity.name,
+    role,
+    flippedCardIds: [],
+  };
+  return normalisePlayer(playerCandidate);
+};
+
+const sortFlippedCards = (grid: Grid, flippedCardIds: string[]): string[] => {
+  const index = new Map(
+    grid.cards.map((card, position) => [card.id, position] as const),
+  );
+  return [...flippedCardIds].sort((left, right) => {
+    const leftIndex = index.get(left);
+    const rightIndex = index.get(right);
+    if (leftIndex === undefined || rightIndex === undefined) {
+      return 0;
+    }
+    return leftIndex - rightIndex;
+  });
+};
+
+const requireTwoPlayers = (players: Player[], action: Action): void => {
+  assert(
+    players.length === 2,
+    action,
+    "Exactly two players must participate in a match",
+  );
+};
+
+const clonePlayers = (players: Player[]): Player[] =>
+  players.map((player) => ({
+    ...player,
+    flippedCardIds: [...player.flippedCardIds],
+  }));
+
+const parseGrid = (grid: Grid): Grid => {
+  const parsed = gridSchema.parse(grid);
+  return {
+    ...parsed,
+    cards: parsed.cards.map((card) => cardSchema.parse(card)),
+  };
+};
+
+const determineNextPlayerId = (state: PlayingState): string => {
+  const currentIndex = state.players.findIndex(
+    (player) => player.id === state.activePlayerId,
+  );
+  if (currentIndex === -1) {
+    return state.activePlayerId;
+  }
+  const nextIndex = (currentIndex + 1) % state.players.length;
+  return state.players[nextIndex]?.id ?? state.activePlayerId;
+};
+
+const toFinishedState = (
+  state: PlayingState,
+  winnerId: string,
+  reason: FinishedState["reason"],
+  finalGuess: GuessResult,
+): FinishedState => ({
+  status: GameStatus.Finished,
+  hostId: state.hostId,
+  grid: state.grid,
+  players: clonePlayers(state.players),
+  turn: state.turn,
+  winnerId,
+  reason,
+  finalGuess,
+});
+
+export const reduceGameState = (
+  state: GameState,
+  action: Action,
+): GameState => {
+  actionSchema.parse(action);
+
+  switch (action.type) {
+    case "game/createLobby": {
+      expectState(state, GameStatus.Idle, action);
+      const grid = parseGrid(action.payload.grid);
+      const host = createPlayer(action.payload.host, "host");
+
+      return {
+        status: GameStatus.Lobby,
+        hostId: host.id,
+        grid,
+        players: [host],
+      } satisfies LobbyState;
+    }
+
+    case "game/joinLobby": {
+      const lobbyState = expectState(state, GameStatus.Lobby, action);
+      assert(
+        lobbyState.players.length < 2,
+        action,
+        "Lobby already has two players",
+      );
+
+      const identity = playerIdentitySchema.parse(action.payload.player);
+      const alreadyJoined = lobbyState.players.some(
+        (player) => player.id === identity.id,
+      );
+      assert(
+        !alreadyJoined,
+        action,
+        `Player "${identity.id}" is already in the lobby`,
+      );
+
+      const newPlayer = createPlayer(identity, "guest");
+
+      return {
+        ...lobbyState,
+        players: [...lobbyState.players, newPlayer],
+      } satisfies LobbyState;
+    }
+
+    case "game/setSecret": {
+      const lobbyState = expectState(state, GameStatus.Lobby, action);
+      const { playerId, cardId } = action.payload;
+
+      ensureCardBelongsToGrid(lobbyState.grid, cardId, action);
+
+      const playerIndex = lobbyState.players.findIndex(
+        (player) => player.id === playerId,
+      );
+      assert(
+        playerIndex !== -1,
+        action,
+        `Player "${playerId}" is not in the lobby`,
+      );
+
+      const player = lobbyState.players[playerIndex];
+      if (!player) {
+        throw new InvalidGameActionError(
+          action,
+          `Player "${playerId}" is not in the lobby`,
+        );
+      }
+      if (player.secretCardId === cardId) {
+        return lobbyState;
+      }
+
+      const updatedPlayer: Player = normalisePlayer({
+        ...player,
+        secretCardId: cardId,
+      });
+
+      const players = lobbyState.players.map((current, index) =>
+        index === playerIndex ? updatedPlayer : current,
+      );
+
+      return {
+        ...lobbyState,
+        players,
+      } satisfies LobbyState;
+    }
+
+    case "game/start": {
+      const lobbyState = expectState(state, GameStatus.Lobby, action);
+      requireTwoPlayers(lobbyState.players, action);
+
+      const everyoneReady = lobbyState.players.every(
+        (player) => typeof player.secretCardId === "string",
+      );
+      assert(
+        everyoneReady,
+        action,
+        "All players must select a secret card before starting",
+      );
+
+      const startingPlayerId =
+        action.payload.startingPlayerId ?? lobbyState.hostId;
+      const startingPlayer = lobbyState.players.find(
+        (player) => player.id === startingPlayerId,
+      );
+      assert(
+        startingPlayer,
+        action,
+        `Starting player "${startingPlayerId}" is not part of the lobby`,
+      );
+
+      return {
+        status: GameStatus.Playing,
+        hostId: lobbyState.hostId,
+        grid: lobbyState.grid,
+        players: lobbyState.players.map((player) => ({
+          ...player,
+          flippedCardIds: [],
+        })),
+        activePlayerId: startingPlayer.id,
+        turn: 1,
+      } satisfies PlayingState;
+    }
+
+    case "turn/flipCard": {
+      const playingState = expectState(state, GameStatus.Playing, action);
+      const { playerId, cardId } = action.payload;
+
+      assert(
+        playingState.activePlayerId === playerId,
+        action,
+        "Only the active player can flip cards",
+      );
+      ensureCardBelongsToGrid(playingState.grid, cardId, action);
+
+      const playerIndex = playingState.players.findIndex(
+        (player) => player.id === playerId,
+      );
+      assert(
+        playerIndex !== -1,
+        action,
+        `Player "${playerId}" is not part of the match`,
+      );
+
+      const player = playingState.players[playerIndex];
+      if (!player) {
+        throw new InvalidGameActionError(
+          action,
+          `Player "${playerId}" is not part of the match`,
+        );
+      }
+      assert(
+        player.secretCardId !== cardId,
+        action,
+        "A player cannot flip their own secret card",
+      );
+
+      if (player.flippedCardIds.includes(cardId)) {
+        return playingState;
+      }
+
+      const updatedPlayer: Player = {
+        ...player,
+        flippedCardIds: sortFlippedCards(playingState.grid, [
+          ...player.flippedCardIds,
+          cardId,
+        ]),
+      };
+
+      const players = playingState.players.map((current, index) =>
+        index === playerIndex ? updatedPlayer : current,
+      );
+
+      return {
+        ...playingState,
+        players,
+      } satisfies PlayingState;
+    }
+
+    case "turn/end": {
+      const playingState = expectState(state, GameStatus.Playing, action);
+      const { playerId } = action.payload;
+
+      assert(
+        playingState.activePlayerId === playerId,
+        action,
+        "Only the active player can end their turn",
+      );
+      requireTwoPlayers(playingState.players, action);
+
+      const nextPlayerId = determineNextPlayerId(playingState);
+      assert(
+        nextPlayerId !== playingState.activePlayerId,
+        action,
+        "Cannot pass the turn to the same player",
+      );
+
+      return {
+        ...playingState,
+        activePlayerId: nextPlayerId,
+        turn: playingState.turn + 1,
+      } satisfies PlayingState;
+    }
+
+    case "turn/guess": {
+      const playingState = expectState(state, GameStatus.Playing, action);
+      const { playerId, targetPlayerId, cardId } = action.payload;
+
+      assert(
+        playingState.activePlayerId === playerId,
+        action,
+        "Only the active player can guess the opponent card",
+      );
+      assert(
+        playerId !== targetPlayerId,
+        action,
+        "A player cannot guess their own card",
+      );
+      ensureCardBelongsToGrid(playingState.grid, cardId, action);
+
+      const guesser = playingState.players.find(
+        (player) => player.id === playerId,
+      );
+      assert(guesser, action, `Player "${playerId}" is not part of the match`);
+
+      const target = playingState.players.find(
+        (player) => player.id === targetPlayerId,
+      );
+      assert(
+        target,
+        action,
+        `Target player "${targetPlayerId}" is not part of the match`,
+      );
+      assert(
+        target.secretCardId,
+        action,
+        `Target player "${targetPlayerId}" has no secret card`,
+      );
+
+      const correct = target.secretCardId === cardId;
+      const winnerId = correct ? playerId : targetPlayerId;
+      const reason = correct
+        ? GameConclusionReason.CorrectGuess
+        : GameConclusionReason.IncorrectGuess;
+
+      const finalGuess: GuessResult = {
+        guesserId: playerId,
+        targetPlayerId,
+        cardId,
+        correct,
+      };
+
+      return toFinishedState(playingState, winnerId, reason, finalGuess);
+    }
+
+    case "game/reset":
+      return createInitialState();
+
+    default:
+      return state;
+  }
+};
+
+export const selectPlayers = (state: GameState): Player[] => {
+  if (state.status === GameStatus.Idle) {
+    return [];
+  }
+  return state.players;
+};
+
+export const selectPlayerById = (
+  state: GameState,
+  playerId: string,
+): Player | undefined => {
+  return selectPlayers(state).find((player) => player.id === playerId);
+};
+
+export const selectActivePlayer = (state: GameState): Player | undefined => {
+  if (state.status !== GameStatus.Playing) {
+    return undefined;
+  }
+  return selectPlayerById(state, state.activePlayerId);
+};
+
+export const selectWinner = (state: GameState): Player | undefined => {
+  if (state.status !== GameStatus.Finished) {
+    return undefined;
+  }
+  return selectPlayerById(state, state.winnerId);
+};
+
+export const isPlayerReady = (state: GameState, playerId: string): boolean => {
+  const player = selectPlayerById(state, playerId);
+  return Boolean(player?.secretCardId);
+};
+
+export const canStartGame = (state: GameState): boolean => {
+  if (state.status !== GameStatus.Lobby) {
+    return false;
+  }
+  return (
+    state.players.length === 2 &&
+    state.players.every((player) => Boolean(player.secretCardId))
+  );
+};

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -1,0 +1,213 @@
+/**
+ * Core domain types for the Guess Who-style KeyS game.
+ *
+ * The goal is to keep the data contracts explicit, serialisable and easy to validate.
+ * Each exported type is paired with a runtime schema in {@link schema.ts}.
+ */
+export const GameStatus = {
+  Idle: "idle",
+  Lobby: "lobby",
+  Playing: "playing",
+  Finished: "finished",
+} as const;
+
+export type GameStatus = (typeof GameStatus)[keyof typeof GameStatus];
+
+export interface Card {
+  /** Unique identifier for a card. */
+  id: string;
+  /** Display label shown to players. */
+  label: string;
+  /** Optional URL to render the card artwork. */
+  imageUrl?: string;
+  /** Optional short description or hint. */
+  description?: string;
+}
+
+export interface Grid {
+  /** Identifier for the grid configuration. */
+  id: string;
+  /** Human friendly name, e.g. "Classic 4x4". */
+  name: string;
+  /** Number of rows in the layout. */
+  rows: number;
+  /** Number of columns in the layout. */
+  columns: number;
+  /** Cards placed on the grid in reading order. */
+  cards: Card[];
+}
+
+export const PlayerRole = {
+  Host: "host",
+  Guest: "guest",
+} as const;
+
+export type PlayerRole = (typeof PlayerRole)[keyof typeof PlayerRole];
+
+export interface Player {
+  /** Player identifier (shared across peers). */
+  id: string;
+  /** Friendly display name for the UI. */
+  name: string;
+  /** Role of the participant, primarily used for permissions. */
+  role: PlayerRole;
+  /** Identifier of the opponent card this player protects. */
+  secretCardId?: string;
+  /** Ordered list of card identifiers that the player flipped down. */
+  flippedCardIds: string[];
+}
+
+export interface PlayerIdentity {
+  /** Player identifier to associate with a connection. */
+  id: string;
+  /** Preferred display name. */
+  name: string;
+  /** Optional requested role; defaults to guest for joiners. */
+  role?: PlayerRole;
+}
+
+export const GameConclusionReason = {
+  CorrectGuess: "guess-correct",
+  IncorrectGuess: "guess-incorrect",
+} as const;
+
+export type GameConclusionReason =
+  (typeof GameConclusionReason)[keyof typeof GameConclusionReason];
+
+export interface GuessResult {
+  /** Player who attempted the guess. */
+  guesserId: string;
+  /** Opponent targeted by the guess. */
+  targetPlayerId: string;
+  /** Card identifier that was guessed. */
+  cardId: string;
+  /** Whether the guess matched the opponent secret. */
+  correct: boolean;
+}
+
+export interface IdleState {
+  status: typeof GameStatus.Idle;
+  players: [];
+}
+
+export interface LobbyState {
+  status: typeof GameStatus.Lobby;
+  hostId: string;
+  grid: Grid;
+  players: Player[];
+}
+
+export interface PlayingState {
+  status: typeof GameStatus.Playing;
+  hostId: string;
+  grid: Grid;
+  players: Player[];
+  /** Identifier of the player allowed to act. */
+  activePlayerId: string;
+  /** Sequential turn counter starting at 1. */
+  turn: number;
+}
+
+export interface FinishedState {
+  status: typeof GameStatus.Finished;
+  hostId: string;
+  grid: Grid;
+  players: Player[];
+  /** Turn counter frozen at the moment the match ended. */
+  turn: number;
+  /** Identifier of the player that won the match. */
+  winnerId: string;
+  /** Reason describing why the match ended. */
+  reason: GameConclusionReason;
+  /** Details about the final guess that ended the match. */
+  finalGuess: GuessResult;
+}
+
+export type GameState = IdleState | LobbyState | PlayingState | FinishedState;
+
+export type CreateLobbyAction = {
+  type: "game/createLobby";
+  payload: {
+    grid: Grid;
+    host: PlayerIdentity;
+  };
+};
+
+export type JoinLobbyAction = {
+  type: "game/joinLobby";
+  payload: {
+    player: PlayerIdentity;
+  };
+};
+
+export type SetSecretAction = {
+  type: "game/setSecret";
+  payload: {
+    playerId: string;
+    cardId: string;
+  };
+};
+
+export type StartGameAction = {
+  type: "game/start";
+  payload: {
+    startingPlayerId?: string;
+  };
+};
+
+export type FlipCardAction = {
+  type: "turn/flipCard";
+  payload: {
+    playerId: string;
+    cardId: string;
+  };
+};
+
+export type EndTurnAction = {
+  type: "turn/end";
+  payload: {
+    playerId: string;
+  };
+};
+
+export type GuessAction = {
+  type: "turn/guess";
+  payload: {
+    playerId: string;
+    targetPlayerId: string;
+    cardId: string;
+  };
+};
+
+export type ResetAction = {
+  type: "game/reset";
+};
+
+export type Action =
+  | CreateLobbyAction
+  | JoinLobbyAction
+  | SetSecretAction
+  | StartGameAction
+  | FlipCardAction
+  | EndTurnAction
+  | GuessAction
+  | ResetAction;
+
+export type Message =
+  | {
+      type: "game/snapshot";
+      state: GameState;
+      issuedAt: number;
+    }
+  | {
+      type: "game/action";
+      action: Action;
+      issuedAt: number;
+      issuerId: string;
+    }
+  | {
+      type: "game/error";
+      code: string;
+      message: string;
+      issuedAt: number;
+    };


### PR DESCRIPTION
## Summary
- define strongly typed game domain entities and messages for the KeyS match flow
- add comprehensive Zod schemas that validate grids, players, actions, and messages at runtime
- implement a deterministic finite state machine with selectors and exhaustive reducer unit tests

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d04e02b9c0832a9ab06b59ab846e06