### PR TITLE
Implement internal toast primitives and remove radix dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,6 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
-        "@radix-ui/react-toast": "^1.1.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -196,8 +195,6 @@
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
-
-    "@radix-ui/react-toast": ["@radix-ui/react-toast@1.2.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g=="],
 
     "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
-    "@radix-ui/react-toast": "^1.1.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,104 +1,450 @@
 "use client";
 
-import * as ToastPrimitives from "@radix-ui/react-toast";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const ToastProvider = ToastPrimitives.Provider;
+const DEFAULT_HOTKEY: string[] = ["F8"];
+const DEFAULT_LABEL = "Notifications";
+const DEFAULT_DURATION_IN_MS = 5000;
+const TOAST_UNMOUNT_DELAY_IN_MS = 1200;
 
-const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(function ToastViewport({ className, ...props }, ref) {
+type ToastProviderContextValue = {
+  duration: number;
+  label: string;
+  hotkey: string[];
+  registerViewport: (viewport: HTMLElement | null) => void;
+};
+
+const ToastProviderContext =
+  React.createContext<ToastProviderContextValue | null>(null);
+
+type ToastProviderProps = {
+  children?: React.ReactNode;
+  duration?: number;
+  label?: string;
+  hotkey?: string[];
+};
+
+type ToastViewportProps = React.ComponentPropsWithoutRef<"section"> & {
+  label?: string;
+  hotkey?: string[];
+};
+
+type ToastProps = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  duration?: number;
+  forceMount?: true;
+} & React.ComponentPropsWithoutRef<"li">;
+
+type ToastContextValue = {
+  close: () => void;
+  pauseAutoDismiss: () => void;
+  resumeAutoDismiss: () => void;
+  isVisible: boolean;
+};
+
+const ToastContext = React.createContext<ToastContextValue | null>(null);
+
+type ToastActionProps = React.ComponentPropsWithoutRef<"button"> & {
+  altText: string;
+};
+
+type ToastCloseProps = React.ComponentPropsWithoutRef<"button">;
+
+type ToastTitleProps = React.ComponentPropsWithoutRef<"div">;
+
+type ToastDescriptionProps = React.ComponentPropsWithoutRef<"div">;
+
+type ToastActionElement = React.ReactElement<ToastActionProps>;
+
+function isHotkeyMatch(event: KeyboardEvent, hotkey: string[]) {
+  if (hotkey.length === 0) {
+    return false;
+  }
+
+  const normalizedHotkey = hotkey.map((key) => key.toLowerCase());
+  const requiresAlt = normalizedHotkey.includes("alt");
+  const requiresControl =
+    normalizedHotkey.includes("control") || normalizedHotkey.includes("ctrl");
+  const requiresMeta = normalizedHotkey.includes("meta");
+  const requiresShift = normalizedHotkey.includes("shift");
+
+  if (event.altKey !== requiresAlt) {
+    return false;
+  }
+  if (event.ctrlKey !== requiresControl) {
+    return false;
+  }
+  if (event.metaKey !== requiresMeta) {
+    return false;
+  }
+  if (event.shiftKey !== requiresShift) {
+    return false;
+  }
+
+  const nonModifierKeys = normalizedHotkey.filter(
+    (key) => !["alt", "control", "ctrl", "meta", "shift"].includes(key),
+  );
+
+  if (nonModifierKeys.length === 0) {
+    return false;
+  }
+
+  return nonModifierKeys.some((key) => event.key.toLowerCase() === key);
+}
+
+function useToastProviderContext() {
+  const context = React.useContext(ToastProviderContext);
+  if (context) {
+    return context;
+  }
+
+  return {
+    duration: DEFAULT_DURATION_IN_MS,
+    label: DEFAULT_LABEL,
+    hotkey: DEFAULT_HOTKEY,
+    registerViewport: () => {},
+  } satisfies ToastProviderContextValue;
+}
+
+function useToastContext(componentName: string) {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error(
+      `${componentName} must be used within a <Toast /> component.`,
+    );
+  }
+  return context;
+}
+
+function composeRefs<T>(
+  ...refs: (React.Ref<T> | undefined)[]
+): (node: T | null) => void {
+  return (node) => {
+    for (const ref of refs) {
+      if (!ref) {
+        continue;
+      }
+      if (typeof ref === "function") {
+        ref(node);
+        continue;
+      }
+      (ref as React.MutableRefObject<T | null>).current = node;
+    }
+  };
+}
+
+/**
+ * ToastProvider wires global behaviours such as default duration and viewport hotkey
+ * focus handling for every toast rendered inside the provider.
+ */
+const ToastProvider = function ToastProvider({
+  children,
+  duration = DEFAULT_DURATION_IN_MS,
+  label = DEFAULT_LABEL,
+  hotkey = DEFAULT_HOTKEY,
+}: ToastProviderProps) {
+  const viewportRef = React.useRef<HTMLElement | null>(null);
+
+  const registerViewport = React.useCallback((viewport: HTMLElement | null) => {
+    viewportRef.current = viewport;
+  }, []);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isHotkeyMatch(event, hotkey)) {
+        return;
+      }
+
+      const viewport = viewportRef.current;
+      if (!viewport) {
+        return;
+      }
+
+      event.preventDefault();
+      viewport.focus();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [hotkey]);
+
+  const contextValue = React.useMemo<ToastProviderContextValue>(
+    () => ({ duration, label, hotkey, registerViewport }),
+    [duration, label, hotkey, registerViewport],
+  );
+
   return (
-    <ToastPrimitives.Viewport
-      ref={ref}
-      data-slot="toast-viewport"
-      className={cn(
-        "pointer-events-none fixed inset-x-0 top-0 z-[60] flex max-h-screen flex-col gap-3 overflow-y-auto p-4 sm:inset-x-auto sm:right-4 sm:left-auto",
-        className,
-      )}
-      {...props}
-    />
+    <ToastProviderContext.Provider value={contextValue}>
+      {children}
+    </ToastProviderContext.Provider>
+  );
+};
+
+const ToastViewport = React.forwardRef<HTMLElement, ToastViewportProps>(
+  function ToastViewport(
+    { className, label, hotkey, children, ...props },
+    ref,
+  ) {
+    const providerContext = useToastProviderContext();
+    const announcedLabel = label ?? providerContext.label;
+    const effectiveHotkey = hotkey ?? providerContext.hotkey;
+    const hotkeyDescription =
+      effectiveHotkey.length > 0 ? effectiveHotkey.join("+") : undefined;
+
+    return (
+      <section
+        ref={composeRefs(ref, providerContext.registerViewport)}
+        aria-label={
+          hotkeyDescription
+            ? `${announcedLabel} (${hotkeyDescription})`
+            : announcedLabel
+        }
+        tabIndex={-1}
+        data-slot="toast-viewport"
+        className={cn(
+          "pointer-events-none fixed inset-x-0 top-0 z-[60] flex max-h-screen flex-col overflow-y-auto p-4 sm:inset-x-auto sm:right-4 sm:left-auto",
+          className,
+        )}
+        {...props}
+      >
+        <ol className="flex flex-col gap-3">{children}</ol>
+      </section>
+    );
+  },
+);
+
+const Toast = React.forwardRef<HTMLLIElement, ToastProps>(function Toast(
+  {
+    className,
+    open,
+    defaultOpen = false,
+    onOpenChange,
+    duration,
+    forceMount,
+    ...props
+  },
+  ref,
+) {
+  const providerContext = useToastProviderContext();
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolledOpen;
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const [shouldRender, setShouldRender] = React.useState(forceMount ?? isOpen);
+
+  React.useEffect(() => {
+    if (forceMount) {
+      setShouldRender(true);
+      return;
+    }
+
+    if (isOpen) {
+      setShouldRender(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      () => setShouldRender(false),
+      TOAST_UNMOUNT_DELAY_IN_MS,
+    );
+
+    return () => window.clearTimeout(timeout);
+  }, [forceMount, isOpen]);
+
+  const autoDismissTimerRef = React.useRef<number | null>(null);
+
+  const clearAutoDismiss = React.useCallback(() => {
+    if (autoDismissTimerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(autoDismissTimerRef.current);
+    autoDismissTimerRef.current = null;
+  }, []);
+
+  const startAutoDismiss = React.useCallback(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const autoDismissDuration = duration ?? providerContext.duration;
+    if (autoDismissDuration === Infinity || autoDismissDuration <= 0) {
+      return;
+    }
+
+    clearAutoDismiss();
+    autoDismissTimerRef.current = window.setTimeout(() => {
+      handleOpenChange(false);
+    }, autoDismissDuration);
+  }, [
+    clearAutoDismiss,
+    duration,
+    handleOpenChange,
+    isOpen,
+    providerContext.duration,
+  ]);
+
+  React.useEffect(() => {
+    startAutoDismiss();
+    return clearAutoDismiss;
+  }, [startAutoDismiss, clearAutoDismiss]);
+
+  const pauseAutoDismiss = React.useCallback(() => {
+    clearAutoDismiss();
+  }, [clearAutoDismiss]);
+
+  const resumeAutoDismiss = React.useCallback(() => {
+    startAutoDismiss();
+  }, [startAutoDismiss]);
+
+  const contextValue = React.useMemo<ToastContextValue>(
+    () => ({
+      close: () => handleOpenChange(false),
+      pauseAutoDismiss,
+      resumeAutoDismiss,
+      isVisible: Boolean(isOpen),
+    }),
+    [handleOpenChange, pauseAutoDismiss, resumeAutoDismiss, isOpen],
+  );
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      <li
+        ref={ref}
+        aria-live="polite"
+        aria-atomic="true"
+        data-slot="toast"
+        data-state={isOpen ? "open" : "closed"}
+        onMouseEnter={(event) => {
+          pauseAutoDismiss();
+          props.onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          resumeAutoDismiss();
+          props.onMouseLeave?.(event);
+        }}
+        className={cn(
+          "bg-background text-foreground pointer-events-auto flex w-full max-w-md items-start gap-4 rounded-xl border p-4 shadow-lg transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top sm:data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-right",
+          className,
+        )}
+        {...props}
+      />
+    </ToastContext.Provider>
   );
 });
 
-const Toast = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>
->(function Toast({ className, ...props }, ref) {
-  return (
-    <ToastPrimitives.Root
-      ref={ref}
-      data-slot="toast"
-      className={cn(
-        "bg-background text-foreground pointer-events-auto flex w-full max-w-md items-start gap-4 rounded-xl border p-4 shadow-lg transition-all data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top sm:data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-right",
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+const ToastAction = React.forwardRef<HTMLButtonElement, ToastActionProps>(
+  function ToastAction(
+    { className, altText, children, onClick, onFocus, onBlur, ...props },
+    ref,
+  ) {
+    const toast = useToastContext("ToastAction");
 
-const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(function ToastAction({ className, ...props }, ref) {
-  return (
-    <ToastPrimitives.Action
-      ref={ref}
-      data-slot="toast-action"
-      className={cn(
-        "border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-offset-background rounded-md border px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-slot="toast-action"
+        className={cn(
+          "border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-offset-background rounded-md border px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+          className,
+        )}
+        onFocus={(event) => {
+          toast.pauseAutoDismiss();
+          onFocus?.(event);
+        }}
+        onBlur={(event) => {
+          toast.resumeAutoDismiss();
+          onBlur?.(event);
+        }}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            toast.close();
+          }
+        }}
+        {...props}
+      >
+        {children}
+        <span className="sr-only">{altText}</span>
+      </button>
+    );
+  },
+);
 
-const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(function ToastClose({ className, ...props }, ref) {
-  return (
-    <ToastPrimitives.Close
-      ref={ref}
-      data-slot="toast-close"
-      className={cn(
-        "text-muted-foreground hover:text-foreground absolute right-3 top-3 rounded-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-        className,
-      )}
-      {...props}
-    >
-      <XIcon className="size-4" />
-      <span className="sr-only">Fermer</span>
-    </ToastPrimitives.Close>
-  );
-});
+const ToastClose = React.forwardRef<HTMLButtonElement, ToastCloseProps>(
+  function ToastClose({ className, onClick, onFocus, onBlur, ...props }, ref) {
+    const toast = useToastContext("ToastClose");
 
-const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(function ToastTitle({ className, ...props }, ref) {
-  return (
-    <ToastPrimitives.Title
-      ref={ref}
-      data-slot="toast-title"
-      className={cn("text-sm font-semibold", className)}
-      {...props}
-    />
-  );
-});
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-slot="toast-close"
+        className={cn(
+          "text-muted-foreground hover:text-foreground absolute right-3 top-3 rounded-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          className,
+        )}
+        onFocus={(event) => {
+          toast.pauseAutoDismiss();
+          onFocus?.(event);
+        }}
+        onBlur={(event) => {
+          toast.resumeAutoDismiss();
+          onBlur?.(event);
+        }}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            toast.close();
+          }
+        }}
+        {...props}
+      >
+        <XIcon className="size-4" />
+        <span className="sr-only">Fermer</span>
+      </button>
+    );
+  },
+);
+
+const ToastTitle = React.forwardRef<HTMLDivElement, ToastTitleProps>(
+  function ToastTitle({ className, ...props }, ref) {
+    return (
+      <div
+        ref={ref}
+        data-slot="toast-title"
+        className={cn("text-sm font-semibold", className)}
+        {...props}
+      />
+    );
+  },
+);
 
 const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+  HTMLDivElement,
+  ToastDescriptionProps
 >(function ToastDescription({ className, ...props }, ref) {
   return (
-    <ToastPrimitives.Description
+    <div
       ref={ref}
       data-slot="toast-description"
       className={cn("text-muted-foreground text-sm", className)}
@@ -106,6 +452,13 @@ const ToastDescription = React.forwardRef<
     />
   );
 });
+
+ToastViewport.displayName = "ToastViewport";
+Toast.displayName = "Toast";
+ToastAction.displayName = "ToastAction";
+ToastClose.displayName = "ToastClose";
+ToastTitle.displayName = "ToastTitle";
+ToastDescription.displayName = "ToastDescription";
 
 export {
   Toast,
@@ -116,7 +469,4 @@ export {
   ToastTitle,
   ToastViewport,
 };
-export type {
-  ToastActionElement,
-  ToastProps,
-} from "@radix-ui/react-toast";
+export type { ToastActionElement, ToastProps };

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -15,27 +15,28 @@ function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function renderToast({
-        id,
-        title,
-        description,
-        action,
-        ...toastProps
-      }) {
-        return (
-          <Toast key={id} {...toastProps}>
-            <div className="flex flex-1 flex-col gap-1">
-              {title ? <ToastTitle>{title}</ToastTitle> : null}
-              {description ? (
-                <ToastDescription>{description}</ToastDescription>
-              ) : null}
-            </div>
-            {action}
-            <ToastClose />
-          </Toast>
-        );
-      })}
-      <ToastViewport />
+      <ToastViewport>
+        {toasts.map(function renderToast({
+          id,
+          title,
+          description,
+          action,
+          ...toastProps
+        }) {
+          return (
+            <Toast key={id} {...toastProps}>
+              <div className="flex flex-1 flex-col gap-1">
+                {title ? <ToastTitle>{title}</ToastTitle> : null}
+                {description ? (
+                  <ToastDescription>{description}</ToastDescription>
+                ) : null}
+              </div>
+              {action}
+              <ToastClose />
+            </Toast>
+          );
+        })}
+      </ToastViewport>
     </ToastProvider>
   );
 }


### PR DESCRIPTION
## Summary
- replace the Radix toast primitive with a local implementation that handles focus hotkeys, auto-dismiss, and close controls
- render toast entries inside the viewport container and keep Radix toast out of the dependency graph

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d050f68f90832a80b5f97859bf896f