### PR TITLE
feat: add grid editor and join invitation flow

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,140 +1,38 @@
-import { ClipboardCheckIcon, RocketIcon, Settings2Icon } from "lucide-react";
-import Link from "next/link";
+import { ImageIcon, LayoutGridIcon, SparklesIcon } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
-const presets = [
-  {
-    id: "classic",
-    title: "Classique",
-    description: "Grille 5x7 équilibrée, idéale pour une première partie.",
-    details: [
-      "24 personnages pré-configurés avec avatars inclus.",
-      "Rotation automatique des questions pour dynamiser le jeu.",
-      "Durée recommandée : 20 minutes.",
-    ],
-  },
-  {
-    id: "speed",
-    title: "Rapide",
-    description: "Sessions éclair de 10 minutes pour s’échauffer.",
-    details: [
-      "Grille 4x6 pour des parties nerveuses.",
-      "Limite de 30 secondes par question pour maintenir le rythme.",
-      "Score affiché en temps réel pour encourager la prise de risque.",
-    ],
-  },
-  {
-    id: "custom",
-    title: "Personnalisé",
-    description: "Construisez votre configuration de A à Z.",
-    details: [
-      "Importez vos avatars, thèmes et jeux de questions.",
-      "Activez des règles maison : jokers, votes secrets, double chance.",
-      "Exportez le preset pour le partager avec vos co-animateurs.",
-    ],
-  },
-];
+import { GridEditor } from "@/components/editor/GridEditor";
 
 export default function CreatePage() {
   return (
-    <div className="flex flex-col gap-12">
-      <section className="space-y-4">
+    <div className="flex flex-col gap-10">
+      <section className="space-y-5">
         <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
-          <RocketIcon aria-hidden="true" className="size-4" />
-          Configuration d’une nouvelle partie
+          <SparklesIcon aria-hidden="true" className="size-4" />
+          Configuration de la grille
         </div>
         <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Créez votre salle KeyS
+          Créez votre plateau KeyS personnalisé
         </h1>
         <p className="text-base text-muted-foreground sm:text-lg">
-          Choisissez un preset adapté, ajustez les paramètres et partagez le
-          code d’accès. Chaque réglage est pensé pour être modifié ensuite en
-          direct pendant la partie.
+          Définissez vos cartes, importez des visuels et générez un lien
+          sécurisé à partager avec votre invité. L’URL contient toutes les
+          informations pour reconstruire la partie en local.
         </p>
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <LayoutGridIcon
+              aria-hidden="true"
+              className="size-4 text-primary"
+            />
+            Dimensions dynamiques (2 à 8 cases par côté)
+          </div>
+          <div className="flex items-center gap-2">
+            <ImageIcon aria-hidden="true" className="size-4 text-primary" />
+            Images locales ou via URL publique
+          </div>
+        </div>
       </section>
-      <Card className="border border-border/70">
-        <CardHeader className="border-b border-border/70">
-          <CardTitle className="text-xl">Sélection de preset</CardTitle>
-          <CardDescription>
-            Alternez entre nos configurations prêtes à l’emploi ou composez
-            votre session sur mesure.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-5 py-6">
-          <Tabs defaultValue="classic" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-3">
-              {presets.map((preset) => (
-                <TabsTrigger key={preset.id} value={preset.id}>
-                  {preset.title}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            {presets.map((preset) => (
-              <TabsContent
-                key={preset.id}
-                value={preset.id}
-                className="space-y-4 text-sm leading-relaxed text-muted-foreground"
-              >
-                <p className="font-medium text-foreground">
-                  {preset.description}
-                </p>
-                <ul className="space-y-2 pl-4 marker:text-primary">
-                  {preset.details.map((detail) => (
-                    <li key={detail} className="list-disc">
-                      {detail}
-                    </li>
-                  ))}
-                </ul>
-              </TabsContent>
-            ))}
-          </Tabs>
-          <Separator className="bg-border/60" />
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-lg border border-dashed border-border/60 px-4 py-3 text-sm text-muted-foreground">
-              <div className="flex items-center gap-2 font-semibold text-foreground">
-                <Settings2Icon aria-hidden="true" className="size-4" />
-                Paramètres avancés
-              </div>
-              <p>
-                Définissez vos jokers, temporisations et contraintes de
-                questions.
-              </p>
-            </div>
-            <div className="rounded-lg border border-dashed border-border/60 px-4 py-3 text-sm text-muted-foreground">
-              <div className="flex items-center gap-2 font-semibold text-foreground">
-                <ClipboardCheckIcon aria-hidden="true" className="size-4" />
-                Liste de contrôle
-              </div>
-              <p>
-                Vérifiez la connexion de chaque joueur, le niveau audio et la
-                caméra avant de lancer.
-              </p>
-            </div>
-          </div>
-        </CardContent>
-        <CardFooter className="border-t border-border/70">
-          <div className="flex w-full flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-muted-foreground">
-              Une fois le preset validé, le code de session apparaît
-              immédiatement dans la barre du bas.
-            </p>
-            <Button asChild size="lg" className="sm:w-auto">
-              <Link href="/join">Partager le code</Link>
-            </Button>
-          </div>
-        </CardFooter>
-      </Card>
+      <GridEditor />
     </div>
   );
 }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,140 +1,248 @@
+"use client";
+
 import {
+  AlertCircleIcon,
+  ArrowRightIcon,
   KeySquareIcon,
   LinkIcon,
-  QrCodeIcon,
-  ShieldAlertIcon,
+  RefreshCcwIcon,
 } from "lucide-react";
-import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 
+import { GridPreview } from "@/components/editor/GridPreview";
 import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { Grid } from "@/lib/game/types";
+import {
+  decodeGridFromToken,
+  extractTokenFromInput,
+  InvalidShareTokenError,
+} from "@/lib/share/url";
 
-const joinMethods = [
-  {
-    id: "code",
-    icon: KeySquareIcon,
-    title: "Entrer un code",
-    description: "Idéal en visio ou lors d’un partage oral rapide.",
-    steps: [
-      "Saisissez le code unique à 6 caractères transmis par l’animateur.",
-      "Vérifiez que l’icône d’état passe au vert avant de continuer.",
-      "Le plateau se synchronise automatiquement avec la partie en cours.",
-    ],
-  },
-  {
-    id: "link",
-    icon: LinkIcon,
-    title: "Suivre un lien",
-    description: "Pratique pour un partage par message ou e-mail.",
-    steps: [
-      "Cliquez sur le lien reçu : la salle s’ouvre directement dans l’application.",
-      "Confirmez votre pseudo et choisissez votre avatar.",
-      "Vous arrivez dans la salle d’attente en moins de 5 secondes.",
-    ],
-  },
-  {
-    id: "qr",
-    icon: QrCodeIcon,
-    title: "Scanner un QR code",
-    description: "Idéal pour une installation sur écran géant ou tablette.",
-    steps: [
-      "Scannez le QR code affiché par l’animateur ou sur un flyer.",
-      "Autorisez la caméra si nécessaire, puis confirmez l’accès.",
-      "Le mode plein écran se déclenche automatiquement sur mobile.",
-    ],
-  },
-];
+const updateLocationHash = (token: string | null) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const url = new URL(window.location.href);
+  url.hash = token ?? "";
+  window.history.replaceState(null, "", url.toString());
+};
 
 export default function JoinPage() {
+  const [inputValue, setInputValue] = useState("");
+  const [token, setToken] = useState<string | null>(null);
+  const [grid, setGrid] = useState<Grid | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const initialToken = window.location.hash.slice(1);
+    if (initialToken) {
+      setInputValue(initialToken);
+      try {
+        const payload = decodeGridFromToken(initialToken);
+        setToken(initialToken);
+        setGrid(payload.grid);
+        setError(null);
+      } catch (decodeError) {
+        setError(
+          decodeError instanceof Error
+            ? decodeError.message
+            : "Le fragment de l’URL ne correspond pas à un token valide.",
+        );
+      }
+    }
+  }, []);
+
+  const gridSummary = useMemo(() => {
+    if (!grid) {
+      return null;
+    }
+    return {
+      dimensions: `${grid.rows} × ${grid.columns}`,
+      cards: grid.cards.length,
+    };
+  }, [grid]);
+
+  const handleReset = () => {
+    setGrid(null);
+    setToken(null);
+    setInputValue("");
+    setError(null);
+    updateLocationHash(null);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const maybeToken = extractTokenFromInput(inputValue);
+    if (!maybeToken) {
+      setError("Veuillez coller un lien ou un token valide.");
+      setGrid(null);
+      setToken(null);
+      updateLocationHash(null);
+      return;
+    }
+
+    try {
+      const payload = decodeGridFromToken(maybeToken);
+      setGrid(payload.grid);
+      setToken(maybeToken);
+      setInputValue(maybeToken);
+      setError(null);
+      updateLocationHash(maybeToken);
+    } catch (decodeError) {
+      setGrid(null);
+      setToken(null);
+      setError(
+        decodeError instanceof InvalidShareTokenError
+          ? decodeError.message
+          : decodeError instanceof Error
+            ? decodeError.message
+            : "Impossible de décoder ce token.",
+      );
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-12">
-      <section className="space-y-4">
+    <div className="flex flex-col gap-10">
+      <section className="space-y-5">
         <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
           <KeySquareIcon aria-hidden="true" className="size-4" />
-          Rejoindre une partie en cours
+          Importer une grille partagée
         </div>
         <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Rejoignez vos coéquipiers
+          Rejoignez une partie avec un simple lien
         </h1>
         <p className="text-base text-muted-foreground sm:text-lg">
-          Trois méthodes, un objectif : entrer dans la salle en quelques
-          secondes. Utilisez l’option la plus simple selon votre contexte.
+          Collez le lien d’invitation ou le token communiqué par l’hôte. Le
+          plateau est reconstruit localement sans échange de données
+          personnelles.
         </p>
       </section>
-      <Card className="border border-border/70">
-        <CardHeader className="border-b border-border/70">
-          <CardTitle className="text-xl">Méthode d’accès</CardTitle>
-          <CardDescription>
-            Sélectionnez le mode qui correspond à la façon dont vous avez reçu
-            l’invitation.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-5 py-6">
-          <Tabs defaultValue="code" className="space-y-4">
-            <TabsList className="grid w-full grid-cols-3">
-              {joinMethods.map((method) => (
-                <TabsTrigger key={method.id} value={method.id}>
-                  {method.title}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            {joinMethods.map((method) => (
-              <TabsContent
-                key={method.id}
-                value={method.id}
-                className="space-y-4 text-sm leading-relaxed text-muted-foreground"
-              >
-                <div className="flex items-center gap-2 text-foreground">
-                  <method.icon
-                    aria-hidden="true"
-                    className="size-5 text-primary"
-                  />
-                  <p className="font-medium">{method.description}</p>
+
+      <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Coller un lien ou un token</CardTitle>
+            <CardDescription>
+              L’URL générée depuis la page « Créer » contient un fragment `#`
+              avec les informations compressées.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <label
+                  htmlFor="invite-token"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Lien d’invitation ou token
+                </label>
+                <input
+                  id="invite-token"
+                  type="text"
+                  value={inputValue}
+                  onChange={(event) => setInputValue(event.target.value)}
+                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  placeholder="https://exemple.com/join#TOKEN"
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button type="submit" className="flex-1 sm:flex-none">
+                  <LinkIcon aria-hidden="true" className="mr-2 size-4" />
+                  Décoder le lien
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleReset}
+                  className="flex-1 sm:flex-none"
+                >
+                  <RefreshCcwIcon aria-hidden="true" className="mr-2 size-4" />
+                  Réinitialiser
+                </Button>
+              </div>
+            </form>
+            {error ? (
+              <div className="mt-4 flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <AlertCircleIcon aria-hidden="true" className="mt-0.5 size-4" />
+                <span>{error}</span>
+              </div>
+            ) : (
+              <p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+                <ArrowRightIcon aria-hidden="true" className="size-4" />
+                Le token n’est jamais envoyé à un serveur : tout est traité dans
+                votre navigateur.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Aperçu de la grille importée</CardTitle>
+            <CardDescription>
+              Vérifiez les informations avant de lancer la partie.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {grid ? (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+                    <span className="block text-xs font-medium uppercase text-muted-foreground">
+                      Nom
+                    </span>
+                    <span className="text-foreground">{grid.name}</span>
+                  </div>
+                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+                    <span className="block text-xs font-medium uppercase text-muted-foreground">
+                      Identifiant
+                    </span>
+                    <span className="text-foreground">{grid.id}</span>
+                  </div>
+                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+                    <span className="block text-xs font-medium uppercase text-muted-foreground">
+                      Dimensions
+                    </span>
+                    <span className="text-foreground">
+                      {gridSummary?.dimensions}
+                    </span>
+                  </div>
+                  <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm">
+                    <span className="block text-xs font-medium uppercase text-muted-foreground">
+                      Cartes
+                    </span>
+                    <span className="text-foreground">
+                      {gridSummary?.cards}
+                    </span>
+                  </div>
                 </div>
-                <ul className="space-y-2 pl-4 marker:text-primary">
-                  {method.steps.map((step) => (
-                    <li key={step} className="list-disc">
-                      {step}
-                    </li>
-                  ))}
-                </ul>
-              </TabsContent>
-            ))}
-          </Tabs>
-          <Separator className="bg-border/60" />
-          <div className="rounded-lg border border-dashed border-border/60 px-4 py-3 text-sm text-muted-foreground">
-            <div className="flex items-center gap-2 font-semibold text-foreground">
-              <ShieldAlertIcon aria-hidden="true" className="size-4" />
-              Sécurité
-            </div>
-            <p>
-              Ne partagez jamais votre code KeyS publiquement. Si vous suspectez
-              une intrusion, retournez sur la page « Créer » pour régénérer une
-              nouvelle session en un clic.
-            </p>
-          </div>
-        </CardContent>
-        <CardFooter className="border-t border-border/70">
-          <div className="flex w-full flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-muted-foreground">
-              Vous avez reçu un autre lien ? Ouvrez-le directement, cette page
-              s’adapte automatiquement.
-            </p>
-            <Button asChild size="lg" className="sm:w-auto">
-              <Link href="/create">Créer votre propre partie</Link>
-            </Button>
-          </div>
-        </CardFooter>
-      </Card>
+                <GridPreview grid={grid} />
+                {token ? (
+                  <p className="text-xs text-muted-foreground">
+                    Token actuel :{" "}
+                    <span className="font-mono break-all">{token}</span>
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 px-4 py-12 text-center text-sm text-muted-foreground">
+                Aucune grille importée pour le moment. Collez un lien
+                d’invitation pour afficher l’aperçu ici.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/components/editor/CardEditorItem.tsx
+++ b/src/components/editor/CardEditorItem.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import {
+  AlertCircleIcon,
+  CheckCircle2Icon,
+  ImageDownIcon,
+  LinkIcon,
+  Loader2Icon,
+  Trash2Icon,
+} from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { Card } from "@/lib/game/types";
+
+const MAX_FILE_SIZE_BYTES = 200 * 1024; // 200 kB keeps share URLs manageable.
+
+const readableFileSize = (size: number): string => {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} Mo`;
+  }
+  if (size >= 1024) {
+    return `${Math.round(size / 1024)} Ko`;
+  }
+  return `${size} o`;
+};
+
+const readFileAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("Le fichier n’a pas pu être encodé."));
+      }
+    };
+    reader.onerror = () => {
+      reject(new Error("Impossible de lire le fichier local."));
+    };
+    reader.readAsDataURL(file);
+  });
+
+const ensureImageResponse = async (inputUrl: string): Promise<string> => {
+  const url = inputUrl.trim();
+  if (!url) {
+    throw new Error("L’URL de l’image est vide.");
+  }
+
+  if (url.startsWith("data:")) {
+    // Already an inline resource, accept it directly.
+    return url;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { mode: "cors" });
+  } catch (_error) {
+    throw new Error(
+      "Impossible d’accéder à cette URL : le site bloque le chargement CORS ou la connexion a échoué.",
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      "L’image n’a pas pu être téléchargée (statut HTTP invalide).",
+    );
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType || !contentType.startsWith("image/")) {
+    throw new Error("Le contenu téléchargé n’est pas une image valide.");
+  }
+
+  return url;
+};
+
+interface CardEditorItemProps {
+  card: Card;
+  index: number;
+  onChange: (card: Card) => void;
+}
+
+type ImageStatus =
+  | { type: "idle" }
+  | { type: "loading"; message: string }
+  | { type: "success"; message: string }
+  | { type: "error"; message: string };
+
+const DEFAULT_STATUS: ImageStatus = { type: "idle" };
+
+/**
+ * Form controls allowing the user to configure an individual card.
+ * Handles both URL-based imports with CORS validation and inline file uploads.
+ */
+export function CardEditorItem({ card, index, onChange }: CardEditorItemProps) {
+  const labelInputId = useId();
+  const urlInputId = useId();
+  const fileInputId = useId();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const activeRequestRef = useRef(0);
+
+  const [urlInput, setUrlInput] = useState<string>(
+    card.imageUrl && !card.imageUrl.startsWith("data:") ? card.imageUrl : "",
+  );
+  const [status, setStatus] = useState<ImageStatus>(DEFAULT_STATUS);
+
+  useEffect(() => {
+    if (card.imageUrl && !card.imageUrl.startsWith("data:")) {
+      setUrlInput(card.imageUrl);
+    }
+  }, [card.imageUrl]);
+
+  const updateStatus = (nextStatus: ImageStatus) => {
+    setStatus(nextStatus);
+  };
+
+  const handleLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...card, label: event.target.value });
+  };
+
+  const handleUrlSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const requestId = activeRequestRef.current + 1;
+    activeRequestRef.current = requestId;
+
+    if (!urlInput.trim()) {
+      onChange({ ...card, imageUrl: undefined });
+      updateStatus({ type: "success", message: "Image supprimée." });
+      return;
+    }
+
+    try {
+      updateStatus({
+        type: "loading",
+        message: "Vérification des en-têtes CORS…",
+      });
+      const validatedUrl = await ensureImageResponse(urlInput);
+      if (activeRequestRef.current !== requestId) {
+        return;
+      }
+      onChange({ ...card, imageUrl: validatedUrl });
+      updateStatus({ type: "success", message: "Image externe validée." });
+    } catch (error) {
+      if (activeRequestRef.current !== requestId) {
+        return;
+      }
+      updateStatus({
+        type: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Impossible de valider cette URL d’image.",
+      });
+    }
+  };
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const [file] = event.target.files ?? [];
+    if (!file) {
+      return;
+    }
+
+    const requestId = activeRequestRef.current + 1;
+    activeRequestRef.current = requestId;
+
+    if (!file.type.startsWith("image/")) {
+      updateStatus({
+        type: "error",
+        message: "Seuls les fichiers images sont acceptés.",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      updateStatus({
+        type: "error",
+        message: `L’image est trop volumineuse (${readableFileSize(file.size)}). Limite : ${readableFileSize(MAX_FILE_SIZE_BYTES)}.`,
+      });
+      event.target.value = "";
+      return;
+    }
+
+    try {
+      updateStatus({ type: "loading", message: "Encodage de l’image locale…" });
+      const dataUrl = await readFileAsDataUrl(file);
+      if (activeRequestRef.current !== requestId) {
+        return;
+      }
+      onChange({ ...card, imageUrl: dataUrl });
+      setUrlInput("");
+      updateStatus({
+        type: "success",
+        message: "Image locale importée (encodage inline).",
+      });
+    } catch (error) {
+      if (activeRequestRef.current !== requestId) {
+        return;
+      }
+      updateStatus({
+        type: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Le fichier n’a pas pu être importé.",
+      });
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleClearImage = () => {
+    activeRequestRef.current += 1;
+    onChange({ ...card, imageUrl: undefined });
+    setUrlInput("");
+    updateStatus({ type: "success", message: "Image supprimée." });
+  };
+
+  const isInlineImage = Boolean(card.imageUrl?.startsWith("data:"));
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border/70 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <label
+          htmlFor={labelInputId}
+          className="text-sm font-medium text-foreground"
+        >
+          Carte {index + 1}
+        </label>
+        {card.imageUrl ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleClearImage}
+            className="h-8 px-2 text-xs"
+          >
+            <Trash2Icon aria-hidden="true" className="mr-1 size-3.5" />
+            Retirer l’image
+          </Button>
+        ) : null}
+      </div>
+      <input
+        id={labelInputId}
+        type="text"
+        value={card.label}
+        onChange={handleLabelChange}
+        className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        placeholder={`Personnage ${index + 1}`}
+      />
+      <div className="space-y-2">
+        <form className="space-y-2" onSubmit={handleUrlSubmit}>
+          <label
+            htmlFor={urlInputId}
+            className="text-xs font-medium uppercase text-muted-foreground"
+          >
+            URL publique
+          </label>
+          <div className="flex gap-2">
+            <input
+              id={urlInputId}
+              type="url"
+              inputMode="url"
+              value={urlInput}
+              onChange={(event) => setUrlInput(event.target.value)}
+              className="flex-1 rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="https://exemple.com/avatar.png"
+            />
+            <Button
+              type="submit"
+              variant="secondary"
+              size="sm"
+              className="shrink-0"
+            >
+              <LinkIcon aria-hidden="true" className="mr-2 size-4" />
+              Valider
+            </Button>
+          </div>
+        </form>
+        <div className="space-y-2">
+          <label
+            htmlFor={fileInputId}
+            className="text-xs font-medium uppercase text-muted-foreground"
+          >
+            Fichier local
+          </label>
+          <input
+            id={fileInputId}
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            className="block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium file:text-secondary-foreground hover:file:bg-secondary/80"
+          />
+          <p className="text-xs text-muted-foreground">
+            Taille maximale recommandée :{" "}
+            {readableFileSize(MAX_FILE_SIZE_BYTES)} pour préserver la longueur
+            du lien de partage.
+          </p>
+        </div>
+      </div>
+      {status.type !== "idle" ? (
+        <div
+          className={`flex items-center gap-2 rounded-md border px-3 py-2 text-xs ${
+            status.type === "error"
+              ? "border-destructive/60 bg-destructive/10 text-destructive"
+              : status.type === "success"
+                ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
+                : "border-border/60 bg-muted text-muted-foreground"
+          }`}
+        >
+          {status.type === "loading" ? (
+            <Loader2Icon aria-hidden="true" className="size-3.5 animate-spin" />
+          ) : status.type === "success" ? (
+            <CheckCircle2Icon
+              aria-hidden="true"
+              className="size-3.5 text-emerald-600"
+            />
+          ) : (
+            <AlertCircleIcon
+              aria-hidden="true"
+              className="size-3.5 text-destructive"
+            />
+          )}
+          <span>{status.message}</span>
+        </div>
+      ) : null}
+      {card.imageUrl ? (
+        <div className="flex items-center justify-between rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <ImageDownIcon aria-hidden="true" className="size-3.5" />
+            <span>
+              {isInlineImage
+                ? "Image encodée dans le lien (data URI)."
+                : "Image chargée depuis une URL accessible."}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/editor/GridEditor.tsx
+++ b/src/components/editor/GridEditor.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import {
+  AlertCircleIcon,
+  CopyIcon,
+  RefreshCcwIcon,
+  Share2Icon,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useToast } from "@/components/ui/use-toast";
+import type { Card as GameCard, Grid } from "@/lib/game/types";
+import { buildInviteUrl, encodeGridToToken } from "@/lib/share/url";
+
+import { CardEditorItem } from "./CardEditorItem";
+import { GridPreview } from "./GridPreview";
+
+const MIN_DIMENSION = 2;
+const MAX_DIMENSION = 8;
+
+const createRandomId = (prefix: string): string => {
+  const randomSegment =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID().slice(0, 8)
+      : Math.random().toString(36).slice(2, 10);
+  return `${prefix}-${randomSegment}`;
+};
+
+const createCard = (index: number): GameCard => ({
+  id: createRandomId("card"),
+  label: `Personnage ${index + 1}`,
+});
+
+const clampDimension = (value: number): number => {
+  if (Number.isNaN(value)) {
+    return MIN_DIMENSION;
+  }
+  return Math.min(MAX_DIMENSION, Math.max(MIN_DIMENSION, value));
+};
+
+const normaliseLabel = (label: string, fallback: string): string => {
+  const trimmed = label.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+};
+
+interface ShareState {
+  token: string;
+  url: string;
+}
+
+/**
+ * Main grid editor allowing the host to configure board dimensions and cards,
+ * preview the layout and generate a shareable invitation link.
+ */
+export function GridEditor() {
+  const [gridId, setGridId] = useState(() => createRandomId("grid"));
+  const [gridName, setGridName] = useState("Grille personnalisée");
+  const [rows, setRows] = useState(4);
+  const [columns, setColumns] = useState(4);
+  const [cards, setCards] = useState<GameCard[]>(() => {
+    const total = 4 * 4;
+    return Array.from({ length: total }, (_, index) => createCard(index));
+  });
+  const [shareState, setShareState] = useState<ShareState | null>(null);
+  const [shareError, setShareError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [lastSharedSignature, setLastSharedSignature] = useState<string | null>(
+    null,
+  );
+
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const total = rows * columns;
+    setCards((previous) => {
+      if (previous.length === total) {
+        return previous;
+      }
+
+      if (total > previous.length) {
+        const nextCards = [...previous];
+        for (let index = previous.length; index < total; index += 1) {
+          nextCards.push(createCard(index));
+        }
+        return nextCards;
+      }
+
+      return previous.slice(0, total);
+    });
+  }, [rows, columns]);
+
+  const previewGrid: Grid = useMemo(
+    () => ({
+      id: gridId,
+      name: gridName,
+      rows,
+      columns,
+      cards,
+    }),
+    [gridId, gridName, rows, columns, cards],
+  );
+
+  const signature = useMemo(() => JSON.stringify(previewGrid), [previewGrid]);
+
+  const hasUnsavedChanges =
+    shareState !== null && lastSharedSignature !== signature;
+
+  const handleRowsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRows(clampDimension(event.target.valueAsNumber));
+  };
+
+  const handleColumnsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setColumns(clampDimension(event.target.valueAsNumber));
+  };
+
+  const handleCardChange = (index: number, nextCard: GameCard) => {
+    setCards((previous) => {
+      const next = [...previous];
+      next[index] = nextCard;
+      return next;
+    });
+  };
+
+  const regenerateGridId = () => {
+    setGridId(createRandomId("grid"));
+  };
+
+  const handleGenerateLink = () => {
+    setIsGenerating(true);
+    setShareError(null);
+
+    try {
+      const total = rows * columns;
+      if (cards.length !== total) {
+        throw new Error(
+          "Le nombre de cartes doit correspondre exactement à la taille de la grille.",
+        );
+      }
+
+      const trimmedCards: GameCard[] = cards.map((card, index) => ({
+        ...card,
+        label: normaliseLabel(card.label, `Personnage ${index + 1}`),
+        description: card.description?.trim() || undefined,
+      }));
+
+      const trimmedGrid: Grid = {
+        id: normaliseLabel(gridId, createRandomId("grid")),
+        name: normaliseLabel(gridName, "Grille personnalisée"),
+        rows,
+        columns,
+        cards: trimmedCards,
+      };
+
+      setGridId(trimmedGrid.id);
+      setGridName(trimmedGrid.name);
+      setCards(trimmedCards);
+
+      const token = encodeGridToToken(trimmedGrid);
+      const origin = window.location.origin;
+      const url = buildInviteUrl(origin, token);
+
+      setShareState({ token, url });
+      setLastSharedSignature(JSON.stringify(trimmedGrid));
+      toast({
+        title: "Lien de partie généré",
+        description:
+          "Partagez ce lien avec votre invité pour charger la grille.",
+      });
+    } catch (error) {
+      setShareError(
+        error instanceof Error
+          ? error.message
+          : "Une erreur inattendue est survenue lors de la génération du lien.",
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareState?.url) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(shareState.url);
+      toast({
+        title: "Lien copié",
+        description:
+          "L’URL d’invitation est disponible dans votre presse-papier.",
+      });
+    } catch (error) {
+      setShareError(
+        error instanceof Error
+          ? error.message
+          : "Impossible de copier le lien automatiquement.",
+      );
+    }
+  };
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="space-y-8">
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Paramètres de la grille</CardTitle>
+            <CardDescription>
+              Ajustez les dimensions et l’identifiant avant de configurer les
+              cartes.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <label
+                  htmlFor="grid-name"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Nom de la grille
+                </label>
+                <input
+                  id="grid-name"
+                  type="text"
+                  value={gridName}
+                  onChange={(event) => setGridName(event.target.value)}
+                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  placeholder="Tournoi d’entraînement"
+                />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="grid-id"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Identifiant technique
+                  </label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={regenerateGridId}
+                    className="h-8 px-2 text-xs"
+                  >
+                    <RefreshCcwIcon
+                      aria-hidden="true"
+                      className="mr-1 size-3.5"
+                    />
+                    Régénérer
+                  </Button>
+                </div>
+                <input
+                  id="grid-id"
+                  type="text"
+                  value={gridId}
+                  onChange={(event) => setGridId(event.target.value)}
+                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  placeholder="grid-tournoi"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Cet identifiant est inclus dans le lien partagé et permet de
+                  reconnaître la grille.
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <label
+                  htmlFor="grid-rows"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Nombre de lignes
+                </label>
+                <input
+                  id="grid-rows"
+                  type="number"
+                  min={MIN_DIMENSION}
+                  max={MAX_DIMENSION}
+                  value={rows}
+                  onChange={handleRowsChange}
+                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
+              <div className="space-y-2">
+                <label
+                  htmlFor="grid-columns"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Nombre de colonnes
+                </label>
+                <input
+                  id="grid-columns"
+                  type="number"
+                  min={MIN_DIMENSION}
+                  max={MAX_DIMENSION}
+                  value={columns}
+                  onChange={handleColumnsChange}
+                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              La grille contiendra {rows * columns} cartes. Ajustez ensuite
+              chaque carte pour personnaliser les avatars.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Cartes du plateau</CardTitle>
+            <CardDescription>
+              Définissez le nom et l’illustration de chaque carte. Les images en
+              data URI augmentent la taille du lien : privilégiez les URLs
+              publiques lorsque c’est possible.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 lg:grid-cols-2">
+              {cards.map((card, index) => (
+                <CardEditorItem
+                  key={card.id}
+                  card={card}
+                  index={index}
+                  onChange={(nextCard) => handleCardChange(index, nextCard)}
+                />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-8">
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Aperçu</CardTitle>
+            <CardDescription>
+              Vérifiez le rendu final tel qu’il sera affiché aux joueurs.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <GridPreview grid={previewGrid} />
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Lien d’invitation</CardTitle>
+            <CardDescription>
+              Générez un lien compressé contenant la configuration de la grille.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Button
+              type="button"
+              size="lg"
+              onClick={handleGenerateLink}
+              disabled={isGenerating}
+              className="w-full"
+            >
+              <Share2Icon aria-hidden="true" className="mr-2 size-4" />
+              {isGenerating
+                ? "Génération en cours…"
+                : "Créer le lien d’invitation"}
+            </Button>
+            {shareError ? (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <AlertCircleIcon aria-hidden="true" className="mt-0.5 size-4" />
+                <span>{shareError}</span>
+              </div>
+            ) : null}
+            {shareState ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase text-muted-foreground">
+                  <span>URL générée</span>
+                  {hasUnsavedChanges ? (
+                    <span className="font-medium text-amber-600">
+                      Modifications non partagées
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex gap-2">
+                  <input
+                    type="url"
+                    readOnly
+                    value={shareState.url}
+                    className="flex-1 cursor-text rounded-md border border-border/70 bg-muted/50 px-3 py-2 text-sm"
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={handleCopyLink}
+                    className="shrink-0"
+                  >
+                    <CopyIcon aria-hidden="true" className="mr-2 size-4" />
+                    Copier
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Le destinataire doit ouvrir ce lien sur la page « Rejoindre ».
+                  Le fragment (#token) contient la grille compressée.
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Générez un lien pour partager instantanément la configuration
+                avec votre invité.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/GridPreview.tsx
+++ b/src/components/editor/GridPreview.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Card, Grid } from "@/lib/game/types";
+
+interface GridPreviewProps {
+  grid: Grid;
+}
+
+type ImageLoadState = "idle" | "loading" | "loaded" | "error";
+
+function CardPreview({ card }: { card: Card }) {
+  const [status, setStatus] = useState<ImageLoadState>(
+    card.imageUrl ? "loading" : "idle",
+  );
+
+  useEffect(() => {
+    setStatus(card.imageUrl ? "loading" : "idle");
+  }, [card.imageUrl]);
+
+  return (
+    <li className="flex flex-col gap-2 rounded-md border border-border/60 bg-background/80 p-3 shadow-sm">
+      <div className="relative flex aspect-square items-center justify-center overflow-hidden rounded-md bg-muted">
+        {card.imageUrl ? (
+          <>
+            {status !== "loaded" && status !== "error" ? (
+              <Skeleton className="absolute inset-0" />
+            ) : null}
+            <Image
+              src={card.imageUrl}
+              alt={card.label}
+              fill
+              unoptimized
+              sizes="(min-width: 1024px) 200px, (min-width: 768px) 33vw, 50vw"
+              onLoadingComplete={() => setStatus("loaded")}
+              onError={() => setStatus("error")}
+              className={`object-cover transition-opacity duration-200 ${
+                status === "loaded" ? "opacity-100" : "opacity-0"
+              }`}
+            />
+            {status === "error" ? (
+              <span className="z-10 px-2 text-center text-xs text-destructive">
+                Impossible de charger l’image
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <span className="px-2 text-center text-xs text-muted-foreground">
+            Aucune illustration
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-foreground">
+          {card.label}
+        </span>
+        {card.description ? (
+          <p className="text-xs text-muted-foreground">{card.description}</p>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** Visual preview rendering the grid layout exactly as the guests will see it. */
+export function GridPreview({ grid }: GridPreviewProps) {
+  const templateColumns = `repeat(${grid.columns}, minmax(0, 1fr))`;
+
+  if (grid.cards.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground">
+        Ajoutez des cartes pour afficher l’aperçu.
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      className="grid gap-3"
+      style={{ gridTemplateColumns: templateColumns }}
+      aria-label={`Aperçu de la grille ${grid.rows} × ${grid.columns}`}
+    >
+      {grid.cards.map((card) => (
+        <CardPreview key={card.id} card={card} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+/**
+ * Accessible skeleton placeholder used to preview asynchronous content.
+ * The animation remains subtle to avoid distracting nearby text or controls.
+ */
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      aria-hidden="true"
+      {...props}
+    />
+  ),
+);
+Skeleton.displayName = "Skeleton";
+
+export { Skeleton };

--- a/src/lib/share/url.test.ts
+++ b/src/lib/share/url.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+
+import { gridSchema } from "@/lib/game/schema";
+import type { Grid } from "@/lib/game/types";
+
+import {
+  buildInviteUrl,
+  decodeGridFromToken,
+  encodeGridToToken,
+  extractTokenFromInput,
+  InvalidShareTokenError,
+} from "./url";
+
+const createSampleGrid = (): Grid => ({
+  id: "grid-demo",
+  name: "Grille de test",
+  rows: 2,
+  columns: 3,
+  cards: [
+    { id: "card-a", label: "Alpha" },
+    { id: "card-b", label: "Beta" },
+    { id: "card-c", label: "Gamma" },
+    { id: "card-d", label: "Delta" },
+    { id: "card-e", label: "Epsilon" },
+    { id: "card-f", label: "Zeta" },
+  ],
+});
+
+describe("share/url", () => {
+  it("round-trips a grid through compression", () => {
+    const grid = createSampleGrid();
+    const token = encodeGridToToken(grid);
+    const payload = decodeGridFromToken(token);
+
+    expect(payload.grid).toEqual(gridSchema.parse(grid));
+  });
+
+  it("throws a dedicated error for malformed tokens", () => {
+    expect(() => decodeGridFromToken("invalid")).toThrow(
+      InvalidShareTokenError,
+    );
+  });
+
+  it("builds a proper invite URL", () => {
+    const token = "abc";
+    const url = buildInviteUrl("https://example.com", token);
+
+    expect(url).toBe("https://example.com/join#abc");
+  });
+
+  it("extracts tokens from URLs or raw values", () => {
+    expect(extractTokenFromInput("token-value")).toBe("token-value");
+    expect(extractTokenFromInput("https://example.com/join#token")).toBe(
+      "token",
+    );
+    expect(extractTokenFromInput("   ")).toBeNull();
+    expect(extractTokenFromInput("/#inline")).toBe("inline");
+  });
+});

--- a/src/lib/share/url.ts
+++ b/src/lib/share/url.ts
@@ -1,0 +1,113 @@
+import { compressToBase64, decompressFromBase64 } from "lz-string";
+
+import { gridSchema } from "@/lib/game/schema";
+import type { Grid } from "@/lib/game/types";
+
+export const SHARE_PAYLOAD_VERSION = 1 as const;
+
+export interface ShareableGridPayload {
+  version: typeof SHARE_PAYLOAD_VERSION;
+  grid: Grid;
+}
+
+/** Dedicated error thrown when a token cannot be parsed or validated. */
+export class InvalidShareTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidShareTokenError";
+  }
+}
+
+/**
+ * Compresses a grid configuration into a compact Base64 token suitable for URLs.
+ * The data structure is versioned to remain extensible over time.
+ */
+export function encodeGridToToken(grid: Grid): string {
+  const payload: ShareableGridPayload = {
+    version: SHARE_PAYLOAD_VERSION,
+    grid,
+  };
+
+  const json = JSON.stringify(payload);
+  const token = compressToBase64(json);
+
+  if (!token) {
+    throw new Error(
+      "Failed to compress the grid payload into a shareable token",
+    );
+  }
+
+  return token;
+}
+
+/**
+ * Restores a grid configuration from a compressed Base64 token.
+ * Validation is performed using the runtime {@link gridSchema} to guarantee integrity.
+ */
+export function decodeGridFromToken(token: string): ShareableGridPayload {
+  const normalizedToken = token.trim();
+  if (!normalizedToken) {
+    throw new InvalidShareTokenError("Share token cannot be empty");
+  }
+
+  const json = decompressFromBase64(normalizedToken);
+  if (!json) {
+    throw new InvalidShareTokenError(
+      "Unable to decompress the provided share token",
+    );
+  }
+
+  let payload: ShareableGridPayload;
+  try {
+    payload = JSON.parse(json) as ShareableGridPayload;
+  } catch (_error) {
+    throw new InvalidShareTokenError("Share token contains invalid JSON data");
+  }
+
+  if (payload.version !== SHARE_PAYLOAD_VERSION) {
+    throw new InvalidShareTokenError("Unsupported share token version");
+  }
+
+  return {
+    version: SHARE_PAYLOAD_VERSION,
+    grid: gridSchema.parse(payload.grid),
+  };
+}
+
+/**
+ * Builds a full invite URL including the `#/token` fragment.
+ * The origin is normalised to avoid accidental double slashes.
+ */
+export function buildInviteUrl(origin: string, token: string): string {
+  const trimmedOrigin = origin.replace(/\/$/, "");
+  return `${trimmedOrigin}/join#${token}`;
+}
+
+/**
+ * Extracts a share token from a raw user input, which can be either a token
+ * or a full invite URL.
+ */
+export function extractTokenFromInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!trimmed.includes("#")) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.hash.slice(1) || null;
+  } catch (_error) {
+    // The value might not be a valid URL (for instance `/#token`).
+    const fragmentIndex = trimmed.indexOf("#");
+    if (fragmentIndex === -1) {
+      return trimmed;
+    }
+
+    const fragment = trimmed.slice(fragmentIndex + 1);
+    return fragment ? fragment : null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement an interactive grid editor with image import, preview, and share link generation
- add LZ-compressed share token utilities and decode flow on the join page
- introduce reusable skeleton placeholder and unit tests for the sharing module

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d054051c04832ab6e8daf2e7060c88