### PR TITLE
feat: implement p2p game sync protocol and journal

### DIFF
--- a/src/lib/game/schema.ts
+++ b/src/lib/game/schema.ts
@@ -277,6 +277,13 @@ export const resetActionSchema = z
   })
   .strict();
 
+export const synchronisedActionSchema = z.discriminatedUnion("type", [
+  flipCardActionSchema,
+  endTurnActionSchema,
+  guessActionSchema,
+  resetActionSchema,
+]);
+
 export const actionSchema: z.ZodType<Action> = z.discriminatedUnion("type", [
   createLobbyActionSchema,
   joinLobbyActionSchema,
@@ -292,16 +299,35 @@ export const messageSchema: z.ZodType<Message> = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal<"game/snapshot">("game/snapshot"),
+      snapshotId: z.string().min(1),
       state: gameStateSchema,
       issuedAt: z.number().int().nonnegative(),
+      lastActionId: z.string().min(1).nullable(),
     })
     .strict(),
   z
     .object({
       type: z.literal<"game/action">("game/action"),
-      action: actionSchema,
+      actionId: z.string().min(1),
+      action: synchronisedActionSchema,
       issuerId: z.string().min(1),
       issuedAt: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal<"game/snapshot-ack">("game/snapshot-ack"),
+      snapshotId: z.string().min(1),
+      receivedAt: z.number().int().nonnegative(),
+      lastActionId: z.string().min(1).nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal<"game/resync-request">("game/resync-request"),
+      requestedAt: z.number().int().nonnegative(),
+      lastActionId: z.string().min(1).nullable(),
+      reason: z.string().min(1).optional(),
     })
     .strict(),
   z
@@ -320,3 +346,4 @@ export type PlayerSchema = typeof playerSchema;
 export type GameStateSchema = typeof gameStateSchema;
 export type ActionSchema = typeof actionSchema;
 export type MessageSchema = typeof messageSchema;
+export type SynchronisedActionSchema = typeof synchronisedActionSchema;

--- a/src/lib/game/sync.test.ts
+++ b/src/lib/game/sync.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "bun:test";
+
+import { createInitialState, reduceGameState } from "./state";
+import {
+  applyAction,
+  applySnapshot,
+  createGameJournal,
+  GameSyncError,
+} from "./sync";
+import {
+  type GameState,
+  GameStatus,
+  PlayerRole,
+  type PlayingState,
+} from "./types";
+
+const hostId = "player-host";
+const guestId = "player-guest";
+
+const createGrid = () => ({
+  id: "grid-1",
+  name: "Test Grid",
+  rows: 2,
+  columns: 2,
+  cards: [
+    { id: "card-a", label: "Alpha" },
+    { id: "card-b", label: "Beta" },
+    { id: "card-c", label: "Gamma" },
+    { id: "card-d", label: "Delta" },
+  ],
+});
+
+const transitionToLobby = (): GameState => {
+  const initial = createInitialState();
+  const grid = createGrid();
+  const afterCreate = reduceGameState(initial, {
+    type: "game/createLobby",
+    payload: {
+      grid,
+      host: { id: hostId, name: "Host", role: PlayerRole.Host },
+    },
+  });
+
+  return reduceGameState(afterCreate, {
+    type: "game/joinLobby",
+    payload: { player: { id: guestId, name: "Guest", role: PlayerRole.Guest } },
+  });
+};
+
+const transitionToPlaying = (): PlayingState => {
+  const lobby = transitionToLobby();
+  const withHostSecret = reduceGameState(lobby, {
+    type: "game/setSecret",
+    payload: { playerId: hostId, cardId: "card-a" },
+  });
+  const withGuestSecret = reduceGameState(withHostSecret, {
+    type: "game/setSecret",
+    payload: { playerId: guestId, cardId: "card-d" },
+  });
+  const started = reduceGameState(withGuestSecret, {
+    type: "game/start",
+    payload: { startingPlayerId: hostId },
+  });
+  if (started.status !== GameStatus.Playing) {
+    throw new Error("Expected playing state");
+  }
+  return started;
+};
+
+describe("game sync", () => {
+  it("applies actions once and deduplicates duplicates", () => {
+    const journal = createGameJournal();
+    const playing = transitionToPlaying();
+
+    const action = {
+      actionId: "action-1",
+      action: {
+        type: "turn/flipCard" as const,
+        payload: { playerId: hostId, cardId: "card-b" },
+      },
+      issuerId: hostId,
+      issuedAt: 1,
+    };
+
+    const first = applyAction(playing, action, journal);
+    expect(first.applied).toBe(true);
+    expect(first.entry?.actionId).toBe("action-1");
+    const host = first.state.players.find((player) => player.id === hostId);
+    expect(host?.flippedCardIds).toEqual(["card-b"]);
+    expect(journal.size).toBe(1);
+
+    const duplicate = applyAction(first.state, action, journal);
+    expect(duplicate.applied).toBe(false);
+    expect(duplicate.reason).toBe("duplicate");
+    expect(duplicate.state).toBe(first.state);
+    expect(journal.size).toBe(1);
+  });
+
+  it("replays outstanding actions after receiving a snapshot", () => {
+    const journal = createGameJournal();
+    const playing = transitionToPlaying();
+
+    const flip = {
+      actionId: "flip-1",
+      action: {
+        type: "turn/flipCard" as const,
+        payload: { playerId: hostId, cardId: "card-b" },
+      },
+      issuerId: hostId,
+      issuedAt: 1,
+    };
+
+    const endTurn = {
+      actionId: "end-1",
+      action: {
+        type: "turn/end" as const,
+        payload: { playerId: hostId },
+      },
+      issuerId: hostId,
+      issuedAt: 2,
+    };
+
+    const afterFlip = applyAction(playing, flip, journal).state;
+    const afterEnd = applyAction(afterFlip, endTurn, journal).state;
+
+    const snapshot = {
+      snapshotId: "snapshot-1",
+      state: afterFlip,
+      issuedAt: 10,
+      lastActionId: "flip-1",
+    } as const;
+
+    const result = applySnapshot(snapshot, journal);
+    expect(result.replayedActions.map((entry) => entry.actionId)).toEqual([
+      "end-1",
+    ]);
+    expect(result.state).toEqual(afterEnd);
+    expect(journal.size).toBe(1);
+    expect(journal.lastKnownActionId).toBe("end-1");
+  });
+
+  it("drops unknown journal entries when the snapshot cannot align", () => {
+    const journal = createGameJournal();
+    const playing = transitionToPlaying();
+
+    const flip = {
+      actionId: "flip-2",
+      action: {
+        type: "turn/flipCard" as const,
+        payload: { playerId: hostId, cardId: "card-b" },
+      },
+      issuerId: hostId,
+      issuedAt: 1,
+    };
+
+    const afterFlip = applyAction(playing, flip, journal).state;
+
+    const snapshot = {
+      snapshotId: "snapshot-unknown",
+      state: afterFlip,
+      issuedAt: 20,
+      lastActionId: "remote-action",
+    } as const;
+
+    const result = applySnapshot(snapshot, journal);
+    expect(result.replayedActions).toHaveLength(0);
+    expect(result.state).toEqual(afterFlip);
+    expect(journal.size).toBe(0);
+  });
+
+  it("signals a resynchronisation error when outstanding actions cannot replay", () => {
+    const journal = createGameJournal();
+    const playing = transitionToPlaying();
+
+    const flip = {
+      actionId: "flip-3",
+      action: {
+        type: "turn/flipCard" as const,
+        payload: { playerId: hostId, cardId: "card-b" },
+      },
+      issuerId: hostId,
+      issuedAt: 1,
+    };
+
+    applyAction(playing, flip, journal);
+
+    const snapshot = {
+      snapshotId: "snapshot-reset",
+      state: createInitialState(),
+      issuedAt: 30,
+      lastActionId: null,
+    } as const;
+
+    expect(() => applySnapshot(snapshot, journal)).toThrow(GameSyncError);
+    expect(journal.size).toBe(0);
+  });
+});

--- a/src/lib/game/sync.ts
+++ b/src/lib/game/sync.ts
@@ -1,0 +1,333 @@
+import { gameStateSchema, synchronisedActionSchema } from "./schema";
+import { reduceGameState } from "./state";
+import type {
+  GameActionPayload,
+  GameSnapshotPayload,
+  GameState,
+} from "./types";
+
+const clone = <T>(value: T): T => {
+  if (typeof globalThis.structuredClone === "function") {
+    return globalThis.structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const areJournalEntriesEqual = (
+  left: GameJournalEntry,
+  right: GameJournalEntry,
+): boolean =>
+  left.actionId === right.actionId &&
+  left.issuerId === right.issuerId &&
+  left.issuedAt === right.issuedAt &&
+  JSON.stringify(left.action) === JSON.stringify(right.action);
+
+const isSynchronisedActionPayload = (
+  value: GameActionPayload["action"],
+): boolean => {
+  const result = synchronisedActionSchema.safeParse(value);
+  return result.success;
+};
+
+/**
+ * Error thrown whenever synchronisation between peers fails.
+ */
+export class GameSyncError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "GameSyncError";
+    this.cause = options?.cause;
+  }
+}
+
+/**
+ * Action entry stored in the journal to support replays after resynchronisation.
+ */
+export type GameJournalEntry = GameActionPayload;
+
+/**
+ * Minimal snapshot metadata stored in the journal for bookkeeping purposes.
+ */
+export type GameJournalSnapshot = Pick<
+  GameSnapshotPayload,
+  "snapshotId" | "issuedAt" | "lastActionId"
+>;
+
+/**
+ * Configuration options for the in-memory journal implementation.
+ */
+export interface GameJournalOptions {
+  processedRetentionLimit?: number;
+}
+
+/**
+ * Persistent log used to replay actions on top of a known-good snapshot.
+ */
+export interface GameJournal {
+  readonly snapshot: GameJournalSnapshot | null;
+  readonly lastKnownActionId: string | null;
+  readonly size: number;
+  hasProcessed(actionId: string): boolean;
+  get(actionId: string): GameJournalEntry | undefined;
+  append(entry: GameJournalEntry): void;
+  remove(actionId: string): void;
+  reconcileWithSnapshot(
+    snapshot: GameJournalSnapshot,
+  ): readonly GameJournalEntry[];
+  getOutstandingActions(): readonly GameJournalEntry[];
+  clear(): void;
+}
+
+class InMemoryGameJournal implements GameJournal {
+  private readonly entries = new Map<string, GameJournalEntry>();
+  private orderedIds: string[] = [];
+  private readonly processedIds = new Set<string>();
+  private processedOrder: string[] = [];
+  private readonly retentionLimit: number;
+  private _snapshot: GameJournalSnapshot | null = null;
+  private _lastKnownActionId: string | null = null;
+
+  constructor(options?: GameJournalOptions) {
+    this.retentionLimit = Math.max(1, options?.processedRetentionLimit ?? 512);
+  }
+
+  public get snapshot(): GameJournalSnapshot | null {
+    return this._snapshot ? { ...this._snapshot } : null;
+  }
+
+  public get lastKnownActionId(): string | null {
+    return this._lastKnownActionId;
+  }
+
+  public get size(): number {
+    return this.entries.size;
+  }
+
+  public hasProcessed(actionId: string): boolean {
+    return this.processedIds.has(actionId) || this.entries.has(actionId);
+  }
+
+  public get(actionId: string): GameJournalEntry | undefined {
+    const entry = this.entries.get(actionId);
+    return entry ? clone(entry) : undefined;
+  }
+
+  public append(entry: GameJournalEntry): void {
+    const existing = this.entries.get(entry.actionId);
+    if (existing) {
+      if (!areJournalEntriesEqual(existing, entry)) {
+        throw new GameSyncError(
+          `Conflicting payload for action "${entry.actionId}" detected in journal.`,
+        );
+      }
+      return;
+    }
+    if (this.processedIds.has(entry.actionId)) {
+      return;
+    }
+    if (!isSynchronisedActionPayload(entry.action)) {
+      throw new GameSyncError(
+        `Action "${entry.actionId}" with type "${entry.action.type}" is not synchronisable.`,
+      );
+    }
+    const stored = clone(entry);
+    this.entries.set(entry.actionId, stored);
+    const index = this.findInsertionIndex(stored);
+    this.orderedIds.splice(index, 0, entry.actionId);
+    this.markProcessed(entry.actionId);
+    this._lastKnownActionId = entry.actionId;
+  }
+
+  public remove(actionId: string): void {
+    if (!this.entries.delete(actionId)) {
+      return;
+    }
+    const index = this.orderedIds.indexOf(actionId);
+    if (index !== -1) {
+      this.orderedIds.splice(index, 1);
+    }
+  }
+
+  public reconcileWithSnapshot(
+    snapshot: GameJournalSnapshot,
+  ): readonly GameJournalEntry[] {
+    this._snapshot = { ...snapshot };
+    const { lastActionId } = snapshot;
+    if (lastActionId !== null) {
+      this.markProcessed(lastActionId);
+      const index = this.orderedIds.indexOf(lastActionId);
+      if (index === -1) {
+        this.entries.clear();
+        this.orderedIds = [];
+      } else {
+        const appliedIds = this.orderedIds.slice(0, index + 1);
+        for (const id of appliedIds) {
+          this.entries.delete(id);
+        }
+        this.orderedIds = this.orderedIds.slice(index + 1);
+      }
+    }
+    this._lastKnownActionId =
+      this.orderedIds.length > 0
+        ? this.orderedIds[this.orderedIds.length - 1]
+        : snapshot.lastActionId;
+    return this.getOutstandingActions();
+  }
+
+  public getOutstandingActions(): readonly GameJournalEntry[] {
+    return this.orderedIds.map((id) => {
+      const entry = this.entries.get(id);
+      if (!entry) {
+        throw new GameSyncError(
+          `Journal is inconsistent: action "${id}" is missing from storage.`,
+        );
+      }
+      return clone(entry);
+    });
+  }
+
+  public clear(): void {
+    this.entries.clear();
+    this.orderedIds = [];
+    this.processedIds.clear();
+    this.processedOrder = [];
+    this._snapshot = null;
+    this._lastKnownActionId = null;
+  }
+
+  private markProcessed(actionId: string): void {
+    if (this.processedIds.has(actionId)) {
+      return;
+    }
+    this.processedIds.add(actionId);
+    this.processedOrder.push(actionId);
+    this.trimProcessedRetention();
+  }
+
+  private trimProcessedRetention(): void {
+    if (this.processedOrder.length <= this.retentionLimit) {
+      return;
+    }
+    const seen = new Set<string>();
+    while (this.processedOrder.length > this.retentionLimit) {
+      const candidate = this.processedOrder.shift();
+      if (!candidate) {
+        break;
+      }
+      if (this.entries.has(candidate)) {
+        if (seen.has(candidate)) {
+          this.processedOrder.push(candidate);
+          break;
+        }
+        this.processedOrder.push(candidate);
+        seen.add(candidate);
+        continue;
+      }
+      this.processedIds.delete(candidate);
+    }
+  }
+
+  private findInsertionIndex(entry: GameJournalEntry): number {
+    for (let index = 0; index < this.orderedIds.length; index += 1) {
+      const candidate = this.entries.get(this.orderedIds[index]);
+      if (!candidate) {
+        continue;
+      }
+      if (entry.issuedAt < candidate.issuedAt) {
+        return index;
+      }
+      if (
+        entry.issuedAt === candidate.issuedAt &&
+        entry.actionId.localeCompare(candidate.actionId) < 0
+      ) {
+        return index;
+      }
+    }
+    return this.orderedIds.length;
+  }
+}
+
+export const createGameJournal = (options?: GameJournalOptions): GameJournal =>
+  new InMemoryGameJournal(options);
+
+/**
+ * Outcome returned when applying a network action to the local state.
+ */
+export interface ApplyActionResult {
+  state: GameState;
+  applied: boolean;
+  reason?: "duplicate";
+  entry?: GameJournalEntry;
+}
+
+/**
+ * Applies a synchronised action to the provided state while keeping the journal
+ * up to date. Duplicate actions are ignored but do not throw.
+ */
+export const applyAction = (
+  state: GameState,
+  payload: GameActionPayload,
+  journal: GameJournal,
+): ApplyActionResult => {
+  if (journal.hasProcessed(payload.actionId)) {
+    return { state, applied: false, reason: "duplicate" };
+  }
+
+  const parsedAction = synchronisedActionSchema.parse(payload.action);
+
+  let nextState: GameState;
+  try {
+    nextState = reduceGameState(state, parsedAction);
+  } catch (error) {
+    throw new GameSyncError(
+      `Failed to apply action "${payload.actionId}" (${payload.action.type}).`,
+      { cause: error instanceof Error ? error : undefined },
+    );
+  }
+
+  const entry = clone({ ...payload, action: parsedAction });
+  journal.append(entry);
+
+  return { state: nextState, applied: true, entry };
+};
+
+export interface ApplySnapshotResult {
+  state: GameState;
+  replayedActions: readonly GameJournalEntry[];
+}
+
+/**
+ * Replaces the local state with the snapshot payload and replays any
+ * outstanding actions recorded in the journal.
+ */
+export const applySnapshot = (
+  snapshot: GameSnapshotPayload,
+  journal: GameJournal,
+): ApplySnapshotResult => {
+  const state = gameStateSchema.parse(snapshot.state);
+  const outstanding = journal.reconcileWithSnapshot({
+    snapshotId: snapshot.snapshotId,
+    issuedAt: snapshot.issuedAt,
+    lastActionId: snapshot.lastActionId,
+  });
+
+  let nextState = state;
+  const replayed: GameJournalEntry[] = [];
+
+  for (const entry of outstanding) {
+    try {
+      nextState = reduceGameState(nextState, entry.action);
+      replayed.push(entry);
+    } catch (error) {
+      journal.remove(entry.actionId);
+      throw new GameSyncError(
+        `Failed to replay action "${entry.actionId}" while applying snapshot "${snapshot.snapshotId}".`,
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+  }
+
+  return { state: nextState, replayedActions: replayed };
+};

--- a/src/lib/p2p/peer.ts
+++ b/src/lib/p2p/peer.ts
@@ -7,7 +7,7 @@ import Peer, {
 } from "peerjs";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const DEFAULT_SUPPORTED_PROTOCOL_VERSIONS = ["1.0.0"] as const;
+const DEFAULT_SUPPORTED_PROTOCOL_VERSIONS = ["1.1.0", "1.0.0"] as const;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 5000;
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 12000;

--- a/src/lib/p2p/protocol.ts
+++ b/src/lib/p2p/protocol.ts
@@ -1,0 +1,63 @@
+/**
+ * Game-specific protocol definitions used on top of the generic peer runtime.
+ */
+
+import type {
+  GameActionPayload,
+  GameErrorPayload,
+  GameResyncRequestPayload,
+  GameSnapshotAckPayload,
+  GameSnapshotPayload,
+  SynchronisedAction,
+} from "../game/types";
+
+/**
+ * Semantic namespace used when negotiating protocol versions.
+ */
+export const GAME_PROTOCOL_NAMESPACE = "keys.game";
+
+/**
+ * Latest version of the synchronisation protocol. Bump the number whenever the
+ * wire format or behaviour becomes incompatible with previous releases.
+ */
+export const GAME_PROTOCOL_VERSION = "1.1.0" as const;
+
+/**
+ * Ordered list of protocol versions that the application understands. Earlier
+ * entries are preferred when negotiating between peers.
+ */
+export const SUPPORTED_GAME_PROTOCOL_VERSIONS = [
+  GAME_PROTOCOL_VERSION,
+  "1.0.0",
+] as const;
+
+export type GameProtocolVersion =
+  (typeof SUPPORTED_GAME_PROTOCOL_VERSIONS)[number];
+
+/**
+ * Literal action types allowed to circulate after the initial snapshot.
+ */
+export const SYNCHRONISED_ACTION_TYPES: readonly SynchronisedAction["type"][] =
+  ["turn/flipCard", "turn/end", "turn/guess", "game/reset"] as const;
+
+export type SynchronisedActionType = (typeof SYNCHRONISED_ACTION_TYPES)[number];
+
+/**
+ * Payload contract for each game-specific message travelling on the data
+ * channel. The {@link PeerRuntime} implementation automatically wraps the
+ * payload into a timestamped envelope.
+ */
+export interface GameProtocolMessageMap {
+  "game/snapshot": GameSnapshotPayload;
+  "game/snapshot-ack": GameSnapshotAckPayload;
+  "game/action": GameActionPayload;
+  "game/resync-request": GameResyncRequestPayload;
+  "game/error": GameErrorPayload;
+}
+
+export type GameProtocolMessageType = keyof GameProtocolMessageMap;
+
+export type GameProtocolMessage<Type extends GameProtocolMessageType> = {
+  type: Type;
+  payload: GameProtocolMessageMap[Type];
+};


### PR DESCRIPTION
## Summary
- define the game protocol message map and latest semantic version for synchronisation traffic
- extend game message types and schemas with action identifiers, snapshot acknowledgements, and resync requests
- add a journal-driven sync helper that applies snapshots/actions and corresponding unit tests

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d05c194edc832aa0d66fec23cfdbad