### PR TITLE
feat: persist editor drafts and optimise image handling

### DIFF
--- a/src/components/common/ImageSafe.tsx
+++ b/src/components/common/ImageSafe.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+export type ImageLoadStatus = "idle" | "loading" | "loaded" | "error";
+
+const shouldRequestAnonymous = (src?: string): boolean => {
+  if (!src) {
+    return false;
+  }
+  if (src.startsWith("data:")) {
+    return false;
+  }
+  if (src.startsWith("blob:")) {
+    return false;
+  }
+  if (typeof window === "undefined") {
+    return /^https?:/i.test(src);
+  }
+  try {
+    const url = new URL(src, window.location.origin);
+    return url.origin !== window.location.origin;
+  } catch (_error) {
+    return /^https?:/i.test(src);
+  }
+};
+
+export interface ImageSafeProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+  src?: string;
+  alt: string;
+  imageClassName?: string;
+  skeletonClassName?: string;
+  fallback?: React.ReactNode;
+  imageProps?: Omit<
+    React.ImgHTMLAttributes<HTMLImageElement>,
+    "src" | "alt" | "crossOrigin"
+  >;
+  crossOrigin?: "anonymous" | "use-credentials";
+  onStatusChange?: (status: ImageLoadStatus) => void;
+}
+
+export const ImageSafe = React.forwardRef<HTMLImageElement, ImageSafeProps>(
+  (
+    {
+      src,
+      alt,
+      className,
+      imageClassName,
+      skeletonClassName,
+      fallback,
+      imageProps,
+      crossOrigin,
+      onStatusChange,
+      ...containerProps
+    },
+    forwardedRef,
+  ) => {
+    const [status, setStatus] = React.useState<ImageLoadStatus>(
+      src ? "loading" : "idle",
+    );
+
+    const imageRef = React.useRef<HTMLImageElement | null>(null);
+
+    React.useImperativeHandle(forwardedRef, () => imageRef.current);
+
+    React.useEffect(() => {
+      setStatus(src ? "loading" : "idle");
+    }, [src]);
+
+    React.useEffect(() => {
+      if (onStatusChange) {
+        onStatusChange(status);
+      }
+    }, [status, onStatusChange]);
+
+    const resolvedCrossOrigin =
+      crossOrigin ?? (shouldRequestAnonymous(src) ? "anonymous" : undefined);
+
+    const {
+      className: providedImageClassName,
+      onLoad,
+      onError,
+      loading,
+      decoding,
+      ...remainingImageProps
+    } = imageProps ?? {};
+
+    return (
+      <div
+        {...containerProps}
+        className={cn(
+          "relative isolate h-full w-full overflow-hidden",
+          className,
+        )}
+        aria-busy={status === "loading"}
+      >
+        {status === "loading" ? (
+          <Skeleton
+            aria-hidden="true"
+            className={cn("absolute inset-0", skeletonClassName)}
+          />
+        ) : null}
+        {src ? (
+          /* biome-ignore lint/performance/noImgElement: We require direct <img> access to configure crossOrigin for canvas rendering safety. */
+          <img
+            {...remainingImageProps}
+            ref={(node) => {
+              imageRef.current = node;
+              if (typeof forwardedRef === "function") {
+                forwardedRef(node);
+              } else if (forwardedRef) {
+                forwardedRef.current = node;
+              }
+            }}
+            src={src}
+            alt={alt}
+            className={cn(
+              "h-full w-full object-cover transition-opacity duration-200",
+              providedImageClassName,
+              imageClassName,
+              status === "loaded" ? "opacity-100" : "opacity-0",
+            )}
+            crossOrigin={resolvedCrossOrigin}
+            loading={loading ?? "lazy"}
+            decoding={decoding ?? "async"}
+            onLoad={(event) => {
+              setStatus("loaded");
+              onLoad?.(event);
+            }}
+            onError={(event) => {
+              setStatus("error");
+              onError?.(event);
+            }}
+          />
+        ) : null}
+        {(!src || status === "error") && fallback ? (
+          <div className="absolute inset-0 flex items-center justify-center">
+            {fallback}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+ImageSafe.displayName = "ImageSafe";

--- a/src/components/editor/GridPreview.tsx
+++ b/src/components/editor/GridPreview.tsx
@@ -1,52 +1,32 @@
 "use client";
 
-import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
-import { Skeleton } from "@/components/ui/skeleton";
+import { ImageSafe } from "@/components/common/ImageSafe";
 import type { Card, Grid } from "@/lib/game/types";
 
 interface GridPreviewProps {
   grid: Grid;
 }
 
-type ImageLoadState = "idle" | "loading" | "loaded" | "error";
-
 function CardPreview({ card }: { card: Card }) {
-  const [status, setStatus] = useState<ImageLoadState>(
-    card.imageUrl ? "loading" : "idle",
-  );
-
-  useEffect(() => {
-    setStatus(card.imageUrl ? "loading" : "idle");
-  }, [card.imageUrl]);
-
   return (
     <li className="flex flex-col gap-2 rounded-md border border-border/60 bg-background/80 p-3 shadow-sm">
       <div className="relative flex aspect-square items-center justify-center overflow-hidden rounded-md bg-muted">
         {card.imageUrl ? (
-          <>
-            {status !== "loaded" && status !== "error" ? (
-              <Skeleton className="absolute inset-0" />
-            ) : null}
-            <Image
-              src={card.imageUrl}
-              alt={card.label}
-              fill
-              unoptimized
-              sizes="(min-width: 1024px) 200px, (min-width: 768px) 33vw, 50vw"
-              onLoadingComplete={() => setStatus("loaded")}
-              onError={() => setStatus("error")}
-              className={`object-cover transition-opacity duration-200 ${
-                status === "loaded" ? "opacity-100" : "opacity-0"
-              }`}
-            />
-            {status === "error" ? (
+          <ImageSafe
+            src={card.imageUrl}
+            alt={card.label}
+            className="absolute inset-0"
+            fallback={
               <span className="z-10 px-2 text-center text-xs text-destructive">
                 Impossible de charger l’image
               </span>
-            ) : null}
-          </>
+            }
+            imageProps={{
+              sizes: "(min-width: 1024px) 200px, (min-width: 768px) 33vw, 50vw",
+            }}
+          />
         ) : (
           <span className="px-2 text-center text-xs text-muted-foreground">
             Aucune illustration
@@ -67,7 +47,10 @@ function CardPreview({ card }: { card: Card }) {
 
 /** Visual preview rendering the grid layout exactly as the guests will see it. */
 export function GridPreview({ grid }: GridPreviewProps) {
-  const templateColumns = `repeat(${grid.columns}, minmax(0, 1fr))`;
+  const templateColumns = useMemo(
+    () => `repeat(${grid.columns}, minmax(0, 1fr))`,
+    [grid.columns],
+  );
 
   if (grid.cards.length === 0) {
     return (

--- a/src/lib/storage/db.ts
+++ b/src/lib/storage/db.ts
@@ -1,0 +1,422 @@
+import {
+  type DBSchema,
+  type IDBPDatabase,
+  type IDBPTransaction,
+  openDB,
+} from "idb";
+
+import type { GameState, Grid } from "@/lib/game/types";
+
+/**
+ * Centralised IndexedDB access layer used to persist editor drafts and local
+ * game sessions. The store is intentionally simple and strongly typed to avoid
+ * schema drift across migrations.
+ */
+
+const DATABASE_NAME = "cki";
+const DATABASE_VERSION = 1;
+
+const GRID_DRAFT_KEY = "grid:draft:latest";
+
+const STORE_GRID_DRAFTS = "gridDrafts";
+const STORE_IMAGE_ASSETS = "imageAssets";
+const STORE_PARTY_SESSIONS = "partySessions";
+
+/**
+ * Structured metadata associated with an optimised image stored locally.
+ */
+export interface ImageAssetDraft {
+  cardId: string;
+  source: "upload" | "url";
+  mimeType: string;
+  processedBytes: number;
+  originalBytes: number;
+  width?: number;
+  height?: number;
+  originalFileName?: string;
+  originalUrl?: string;
+  createdAt: number;
+}
+
+export interface ImageAssetRecord extends ImageAssetDraft {
+  id: string;
+  gridId: string;
+  dataUrl: string;
+  updatedAt: number;
+}
+
+/**
+ * Share link state persisted alongside the editor draft so that the UI can be
+ * restored faithfully after a refresh.
+ */
+export interface StoredShareState {
+  token: string;
+  url: string;
+}
+
+interface GridDraftRecord {
+  id: string;
+  grid: Grid;
+  shareState: StoredShareState | null;
+  lastSharedSignature: string | null;
+  assets: Record<string, ImageAssetDraft>;
+  updatedAt: number;
+}
+
+export interface PartySessionSnapshot {
+  id: string;
+  state: GameState;
+}
+
+export interface PartySessionRecord extends PartySessionSnapshot {
+  updatedAt: number;
+}
+
+interface CkiDatabaseSchema extends DBSchema {
+  [STORE_GRID_DRAFTS]: {
+    key: string;
+    value: GridDraftRecord;
+  };
+  [STORE_IMAGE_ASSETS]: {
+    key: string;
+    value: ImageAssetRecord;
+    indexes: {
+      "by-grid": string;
+      "by-card": string;
+    };
+  };
+  [STORE_PARTY_SESSIONS]: {
+    key: string;
+    value: PartySessionRecord;
+    indexes: {
+      "by-updated": number;
+    };
+  };
+}
+
+let databasePromise: Promise<IDBPDatabase<CkiDatabaseSchema>> | null = null;
+
+const openDatabase = async (): Promise<IDBPDatabase<CkiDatabaseSchema>> => {
+  if (databasePromise) {
+    return databasePromise;
+  }
+
+  if (typeof indexedDB === "undefined") {
+    throw new Error("IndexedDB n’est pas disponible dans cet environnement.");
+  }
+
+  databasePromise = openDB<CkiDatabaseSchema>(DATABASE_NAME, DATABASE_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_GRID_DRAFTS)) {
+        db.createObjectStore(STORE_GRID_DRAFTS, { keyPath: "id" });
+      }
+
+      if (!db.objectStoreNames.contains(STORE_IMAGE_ASSETS)) {
+        const store = db.createObjectStore(STORE_IMAGE_ASSETS, {
+          keyPath: "id",
+        });
+        store.createIndex("by-grid", "gridId");
+        store.createIndex("by-card", "cardId");
+      }
+
+      if (!db.objectStoreNames.contains(STORE_PARTY_SESSIONS)) {
+        const store = db.createObjectStore(STORE_PARTY_SESSIONS, {
+          keyPath: "id",
+        });
+        store.createIndex("by-updated", "updatedAt");
+      }
+    },
+  });
+
+  return databasePromise;
+};
+
+const createImageAssetId = (gridId: string, cardId: string): string =>
+  `${gridId}::${cardId}`;
+
+const estimateBase64Bytes = (dataUrl: string): number => {
+  const [, base64 = ""] = dataUrl.split(",");
+  if (!base64) {
+    return 0;
+  }
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.max(0, (base64.length * 3) / 4 - padding);
+};
+
+const extractMimeType = (dataUrl: string): string => {
+  const match = /^data:([^;]+);/i.exec(dataUrl);
+  return match?.[1] ?? "image/png";
+};
+
+const deleteAssetsForGrid = async (
+  database: IDBPDatabase<CkiDatabaseSchema>,
+  gridId: string,
+) => {
+  const transaction = database.transaction(STORE_IMAGE_ASSETS, "readwrite");
+  const store = transaction.store;
+  const index = store.index("by-grid");
+  let cursor = await index.openKeyCursor(gridId);
+
+  while (cursor) {
+    const primaryKey = cursor.primaryKey;
+    if (typeof primaryKey === "string") {
+      await store.delete(primaryKey);
+    }
+    cursor = await cursor.continue();
+  }
+
+  await transaction.done;
+};
+
+const putAssetRecords = async (
+  transaction: IDBPTransaction<
+    CkiDatabaseSchema,
+    [typeof STORE_GRID_DRAFTS, typeof STORE_IMAGE_ASSETS],
+    "readwrite"
+  >,
+  grid: Grid,
+  assets: Record<string, ImageAssetDraft>,
+) => {
+  const assetStore = transaction.objectStore(STORE_IMAGE_ASSETS);
+  const now = Date.now();
+  const activeAssetIds = new Set<string>();
+
+  for (const card of grid.cards) {
+    if (!card.imageUrl) {
+      continue;
+    }
+    if (!card.imageUrl.startsWith("data:")) {
+      continue;
+    }
+
+    const metadata = assets[card.id];
+    const assetId = createImageAssetId(grid.id, card.id);
+    activeAssetIds.add(assetId);
+
+    const record: ImageAssetRecord = {
+      id: assetId,
+      gridId: grid.id,
+      cardId: card.id,
+      dataUrl: card.imageUrl,
+      mimeType: metadata?.mimeType ?? extractMimeType(card.imageUrl),
+      processedBytes:
+        metadata?.processedBytes ?? estimateBase64Bytes(card.imageUrl),
+      originalBytes: metadata?.originalBytes ?? metadata?.processedBytes ?? 0,
+      width: metadata?.width,
+      height: metadata?.height,
+      originalFileName: metadata?.originalFileName,
+      originalUrl: metadata?.originalUrl,
+      source: metadata?.source ?? "upload",
+      createdAt: metadata?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    await assetStore.put(record);
+  }
+
+  const index = assetStore.index("by-grid");
+  let cursor = await index.openKeyCursor(grid.id);
+  while (cursor) {
+    const primaryKey = cursor.primaryKey;
+    if (typeof primaryKey === "string" && !activeAssetIds.has(primaryKey)) {
+      await assetStore.delete(primaryKey);
+    }
+    cursor = await cursor.continue();
+  }
+};
+
+export interface GridDraftSnapshot {
+  grid: Grid;
+  shareState: StoredShareState | null;
+  lastSharedSignature: string | null;
+  assets: Record<string, ImageAssetDraft>;
+}
+
+export interface PersistedGridDraft extends GridDraftSnapshot {
+  updatedAt: number;
+}
+
+/**
+ * Retrieve the last saved grid editor draft if it exists.
+ */
+export const loadGridDraft = async (): Promise<PersistedGridDraft | null> => {
+  try {
+    const database = await openDatabase();
+    const record = await database
+      .transaction(STORE_GRID_DRAFTS)
+      .store.get(GRID_DRAFT_KEY);
+    if (!record) {
+      return null;
+    }
+    return {
+      grid: record.grid,
+      shareState: record.shareState,
+      lastSharedSignature: record.lastSharedSignature,
+      assets: record.assets ?? {},
+      updatedAt: record.updatedAt,
+    };
+  } catch (error) {
+    console.error("Échec du chargement du brouillon de grille.", error);
+    return null;
+  }
+};
+
+/**
+ * Persist the current grid draft as well as any processed image assets.
+ */
+export const saveGridDraft = async (
+  draft: GridDraftSnapshot,
+): Promise<void> => {
+  try {
+    const database = await openDatabase();
+    const transaction = database.transaction(
+      [STORE_GRID_DRAFTS, STORE_IMAGE_ASSETS],
+      "readwrite",
+    );
+
+    const gridStore = transaction.objectStore(STORE_GRID_DRAFTS);
+    const previousRecord = await gridStore.get(GRID_DRAFT_KEY);
+
+    const now = Date.now();
+    const filteredAssets: Record<string, ImageAssetDraft> = {};
+    for (const card of draft.grid.cards) {
+      const metadata = draft.assets[card.id];
+      if (metadata) {
+        filteredAssets[card.id] = metadata;
+      }
+    }
+
+    const record: GridDraftRecord = {
+      id: GRID_DRAFT_KEY,
+      grid: draft.grid,
+      shareState: draft.shareState,
+      lastSharedSignature: draft.lastSharedSignature,
+      assets: filteredAssets,
+      updatedAt: now,
+    };
+
+    await gridStore.put(record);
+    await putAssetRecords(transaction, draft.grid, filteredAssets);
+    await transaction.done;
+
+    if (previousRecord && previousRecord.grid.id !== draft.grid.id) {
+      await deleteAssetsForGrid(database, previousRecord.grid.id);
+    }
+  } catch (error) {
+    console.error("Échec de l’enregistrement du brouillon de grille.", error);
+  }
+};
+
+/**
+ * Remove the persisted grid draft and any associated assets.
+ */
+export const clearGridDraft = async (): Promise<void> => {
+  try {
+    const database = await openDatabase();
+    const record = await database
+      .transaction(STORE_GRID_DRAFTS)
+      .store.get(GRID_DRAFT_KEY);
+    const transaction = database.transaction(
+      [STORE_GRID_DRAFTS, STORE_IMAGE_ASSETS],
+      "readwrite",
+    );
+    await transaction.objectStore(STORE_GRID_DRAFTS).delete(GRID_DRAFT_KEY);
+    await transaction.done;
+    if (record) {
+      await deleteAssetsForGrid(database, record.grid.id);
+    }
+  } catch (error) {
+    console.error("Impossible de supprimer le brouillon enregistré.", error);
+  }
+};
+
+/**
+ * Retrieve all stored assets for the provided grid identifier.
+ */
+export const loadImageAssetsForGrid = async (
+  gridId: string,
+): Promise<ImageAssetRecord[]> => {
+  try {
+    const database = await openDatabase();
+    const transaction = database.transaction(STORE_IMAGE_ASSETS);
+    const index = transaction.store.index("by-grid");
+    return await index.getAll(gridId);
+  } catch (error) {
+    console.error("Échec du chargement des images locales.", error);
+    return [];
+  }
+};
+
+/**
+ * Persist a full party session state so that a host can resume after a
+ * disconnection or refresh.
+ */
+export const savePartySession = async (
+  session: PartySessionSnapshot,
+): Promise<void> => {
+  try {
+    const database = await openDatabase();
+    await database.transaction(STORE_PARTY_SESSIONS, "readwrite").store.put({
+      ...session,
+      updatedAt: Date.now(),
+    });
+  } catch (error) {
+    console.error("Échec de l’enregistrement de la session de partie.", error);
+  }
+};
+
+/**
+ * Retrieve a previously stored party session.
+ */
+export const loadPartySession = async (
+  sessionId: string,
+): Promise<PartySessionRecord | null> => {
+  try {
+    const database = await openDatabase();
+    const record = await database
+      .transaction(STORE_PARTY_SESSIONS)
+      .store.get(sessionId);
+    return record ?? null;
+  } catch (error) {
+    console.error(
+      "Impossible de charger la session de partie demandée.",
+      error,
+    );
+    return null;
+  }
+};
+
+/**
+ * Remove a stored party session and free up the associated storage.
+ */
+export const deletePartySession = async (sessionId: string): Promise<void> => {
+  try {
+    const database = await openDatabase();
+    await database
+      .transaction(STORE_PARTY_SESSIONS, "readwrite")
+      .store.delete(sessionId);
+  } catch (error) {
+    console.error("Impossible de supprimer la session de partie.", error);
+  }
+};
+
+/**
+ * List stored party sessions ordered by last update descending.
+ */
+export const listPartySessions = async (): Promise<PartySessionRecord[]> => {
+  try {
+    const database = await openDatabase();
+    const transaction = database.transaction(STORE_PARTY_SESSIONS);
+    const index = transaction.store.index("by-updated");
+    const sessions: PartySessionRecord[] = [];
+    let cursor = await index.openCursor(null, "prev");
+    while (cursor) {
+      sessions.push(cursor.value);
+      cursor = await cursor.continue();
+    }
+    return sessions;
+  } catch (error) {
+    console.error("Échec de la récupération des sessions enregistrées.", error);
+    return [];
+  }
+};

--- a/src/lib/storage/image-processor.ts
+++ b/src/lib/storage/image-processor.ts
@@ -1,0 +1,121 @@
+import type {
+  ImageProcessOptions,
+  ImageProcessRequest,
+  ImageWorkerResponse,
+  ProcessedImage,
+} from "@/workers/image.types";
+
+const DEFAULT_OPTIONS: ImageProcessOptions = {
+  maxWidth: 512,
+  maxHeight: 512,
+  format: "image/webp",
+  quality: 0.82,
+};
+
+type PendingRequest = {
+  resolve: (value: ProcessedImage) => void;
+  reject: (reason: Error) => void;
+};
+
+let worker: Worker | null = null;
+const pendingRequests = new Map<string, PendingRequest>();
+
+const createWorker = (): Worker => {
+  if (typeof window === "undefined") {
+    throw new Error("Le traitement d’image nécessite un contexte navigateur.");
+  }
+
+  const instance = new Worker(
+    new URL("../../workers/image.ts", import.meta.url),
+    { type: "module" },
+  );
+
+  instance.addEventListener(
+    "message",
+    (event: MessageEvent<ImageWorkerResponse>) => {
+      const message = event.data;
+      if (!message || !message.id) {
+        return;
+      }
+      const pending = pendingRequests.get(message.id);
+      if (!pending) {
+        return;
+      }
+      pendingRequests.delete(message.id);
+      if (message.success) {
+        pending.resolve(message.result);
+      } else {
+        pending.reject(new Error(message.error));
+      }
+    },
+  );
+
+  instance.addEventListener("error", (event) => {
+    console.error("Erreur non gérée dans le worker d’image.", event);
+  });
+
+  return instance;
+};
+
+const ensureWorker = (): Worker => {
+  if (!worker) {
+    worker = createWorker();
+  }
+  return worker;
+};
+
+const createRequestId = (): string => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `img-${Math.random().toString(36).slice(2, 12)}`;
+};
+
+export interface ProcessImageOptions extends Partial<ImageProcessOptions> {}
+
+export const processImage = async (
+  blob: Blob,
+  options: ProcessImageOptions = {},
+): Promise<ProcessedImage> => {
+  const workerInstance = ensureWorker();
+  const requestId = createRequestId();
+
+  const payloadOptions: ImageProcessOptions = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+
+  const request: ImageProcessRequest = {
+    id: requestId,
+    type: "process-image",
+    payload: {
+      blob,
+      options: payloadOptions,
+    },
+  };
+
+  return new Promise<ProcessedImage>((resolve, reject) => {
+    pendingRequests.set(requestId, {
+      resolve,
+      reject,
+    });
+    try {
+      workerInstance.postMessage(request, [blob]);
+    } catch (error) {
+      pendingRequests.delete(requestId);
+      reject(
+        error instanceof Error
+          ? error
+          : new Error("Impossible d’envoyer l’image au worker."),
+      );
+    }
+  });
+};
+
+export const disposeImageWorker = () => {
+  if (worker) {
+    worker.terminate();
+    worker = null;
+    pendingRequests.clear();
+  }
+};

--- a/src/workers/image.ts
+++ b/src/workers/image.ts
@@ -1,0 +1,142 @@
+/// <reference lib="webworker" />
+
+import type {
+  ImageProcessOptions,
+  ImageProcessRequest,
+  ImageWorkerResponse,
+  ProcessedImage,
+} from "./image.types";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+const DEFAULT_FALLBACK_FORMAT = "image/png";
+
+const toDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Le contenu image n’a pas pu être converti."));
+      }
+    };
+    reader.onerror = () => {
+      reject(new Error("La lecture du flux image a échoué."));
+    };
+    reader.readAsDataURL(blob);
+  });
+
+const computeTargetDimensions = (
+  width: number,
+  height: number,
+  options: ImageProcessOptions,
+) => {
+  const widthRatio = options.maxWidth / width;
+  const heightRatio = options.maxHeight / height;
+  const scale = Math.min(widthRatio, heightRatio, 1);
+  const targetWidth = Math.max(1, Math.round(width * scale));
+  const targetHeight = Math.max(1, Math.round(height * scale));
+  return { targetWidth, targetHeight };
+};
+
+const renderBitmap = async (
+  bitmap: ImageBitmap,
+  originalBlob: Blob,
+  options: ImageProcessOptions,
+): Promise<{ blob: Blob; width: number; height: number }> => {
+  const { targetWidth, targetHeight } = computeTargetDimensions(
+    bitmap.width,
+    bitmap.height,
+    options,
+  );
+
+  if (typeof OffscreenCanvas === "undefined") {
+    return {
+      blob: originalBlob,
+      width: bitmap.width,
+      height: bitmap.height,
+    };
+  }
+
+  const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Impossible d’initialiser le contexte de rendu.");
+  }
+  context.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+
+  try {
+    const blob = await canvas.convertToBlob({
+      type: options.format,
+      quality: options.quality,
+    });
+    return { blob, width: targetWidth, height: targetHeight };
+  } catch (error) {
+    console.warn(
+      "Échec de la conversion vers le format demandé, recours au PNG.",
+      error,
+    );
+    const blob = await canvas.convertToBlob({
+      type: DEFAULT_FALLBACK_FORMAT,
+    });
+    return { blob, width: targetWidth, height: targetHeight };
+  }
+};
+
+const processBlob = async (
+  blob: Blob,
+  options: ImageProcessOptions,
+): Promise<ProcessedImage> => {
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const {
+      blob: processedBlob,
+      width,
+      height,
+    } = await renderBitmap(bitmap, blob, options);
+    const dataUrl = await toDataUrl(processedBlob);
+    return {
+      dataUrl,
+      width,
+      height,
+      mimeType: processedBlob.type || options.format,
+      byteLength: processedBlob.size,
+    };
+  } finally {
+    bitmap.close();
+  }
+};
+
+self.addEventListener(
+  "message",
+  async (event: MessageEvent<ImageProcessRequest>) => {
+    const message = event.data;
+    if (!message || message.type !== "process-image") {
+      return;
+    }
+
+    try {
+      const result = await processBlob(
+        message.payload.blob,
+        message.payload.options,
+      );
+      const response: ImageWorkerResponse = {
+        id: message.id,
+        success: true,
+        result,
+      };
+      self.postMessage(response);
+    } catch (error) {
+      const response: ImageWorkerResponse = {
+        id: message.id,
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Le traitement de l’image a échoué.",
+      };
+      self.postMessage(response);
+    }
+  },
+);

--- a/src/workers/image.types.ts
+++ b/src/workers/image.types.ts
@@ -1,0 +1,37 @@
+export interface ImageProcessOptions {
+  maxWidth: number;
+  maxHeight: number;
+  format: string;
+  quality: number;
+}
+
+export interface ImageProcessRequest {
+  id: string;
+  type: "process-image";
+  payload: {
+    blob: Blob;
+    options: ImageProcessOptions;
+  };
+}
+
+export interface ProcessedImage {
+  dataUrl: string;
+  width: number;
+  height: number;
+  mimeType: string;
+  byteLength: number;
+}
+
+export interface ImageProcessSuccess {
+  id: string;
+  success: true;
+  result: ProcessedImage;
+}
+
+export interface ImageProcessFailure {
+  id: string;
+  success: false;
+  error: string;
+}
+
+export type ImageWorkerResponse = ImageProcessSuccess | ImageProcessFailure;


### PR DESCRIPTION
## Summary
* introduce an IndexedDB storage layer for grid drafts, processed images and party sessions so that editor state can be restored after reloads.【F:src/lib/storage/db.ts†L16-L308】
* add a dedicated image-processing worker and client helper to resize/encode heavy assets without blocking the UI thread.【F:src/lib/storage/image-processor.ts†L1-L120】【F:src/workers/image.ts†L1-L142】【F:src/workers/image.types.ts†L1-L37】
* rework the card editor to process uploads and URLs through the worker, track metadata, and display optimisation feedback.【F:src/components/editor/CardEditorItem.tsx†L1-L398】
* persist grid editor drafts, including asset metadata, and wire image callbacks through to card items for storage updates.【F:src/components/editor/GridEditor.tsx†L16-L353】
* create an `ImageSafe` component that handles skeletons and cross-origin loading, and use it in the grid preview for safe rendering.【F:src/components/common/ImageSafe.tsx†L1-L146】【F:src/components/editor/GridPreview.tsx†L1-L74】

## Testing
* bun run lint【baa9c3†L1-L3】

------
https://chatgpt.com/codex/tasks/task_e_68d05ff3bdb8832a8ca0b2027d813e4a