### PR TITLE
Add host nickname gate and persist session setup

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,8 +1,102 @@
-import { ImageIcon, LayoutGridIcon, SparklesIcon } from "lucide-react";
+"use client";
 
-import { GridEditor } from "@/components/editor/GridEditor";
+import { ImageIcon, LayoutGridIcon, SparklesIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  GridEditor,
+  type GridEditorHandle,
+} from "@/components/editor/GridEditor";
+import { Button } from "@/components/ui/button";
+import type { Grid } from "@/lib/game/types";
+import {
+  loadLatestNickname,
+  persistHostPreparation,
+  persistLatestNickname,
+} from "@/lib/storage/session";
+
+const createRoomId = (): string => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `room-${Math.random().toString(36).slice(2, 10)}`;
+};
 
 export default function CreatePage() {
+  const router = useRouter();
+  const gridEditorRef = useRef<GridEditorHandle | null>(null);
+  const [nickname, setNickname] = useState("");
+  const [nicknameTouched, setNicknameTouched] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+
+  useEffect(() => {
+    const stored = loadLatestNickname();
+    if (stored) {
+      setNickname(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    persistLatestNickname(nickname);
+  }, [nickname]);
+
+  const handleStartGame = () => {
+    setNicknameTouched(true);
+    setStartError(null);
+
+    const trimmedNickname = nickname.trim();
+    if (!trimmedNickname) {
+      setStartError("Veuillez renseigner un pseudo pour démarrer la partie.");
+      return;
+    }
+
+    const editor = gridEditorRef.current;
+    if (!editor) {
+      setStartError("La grille n’est pas prête. Veuillez réessayer.");
+      return;
+    }
+
+    let grid: Grid;
+    try {
+      grid = editor.commitGrid();
+    } catch (error) {
+      setStartError(
+        error instanceof Error
+          ? error.message
+          : "Impossible de préparer le plateau. Recommencez.",
+      );
+      return;
+    }
+
+    const assets = editor.getAssets();
+    const roomId = createRoomId();
+
+    try {
+      persistHostPreparation({
+        roomId,
+        nickname: trimmedNickname,
+        grid,
+        assets,
+      });
+    } catch (error) {
+      setStartError(
+        error instanceof Error
+          ? error.message
+          : "Impossible d’enregistrer la préparation de partie.",
+      );
+      return;
+    }
+
+    setIsStarting(true);
+    router.push(`/room/${roomId}`).catch((navigationError) => {
+      console.error("Navigation vers la salle échouée.", navigationError);
+      setStartError("La redirection vers la salle a échoué. Réessayez.");
+      setIsStarting(false);
+    });
+  };
+
   return (
     <div className="flex flex-col gap-10">
       <section className="space-y-5">
@@ -14,9 +108,8 @@ export default function CreatePage() {
           Créez votre plateau KeyS personnalisé
         </h1>
         <p className="text-base text-muted-foreground sm:text-lg">
-          Définissez vos cartes, importez des visuels et générez un lien
-          sécurisé à partager avec votre invité. L’URL contient toutes les
-          informations pour reconstruire la partie en local.
+          Définissez vos cartes, importez des visuels et préparez la partie. Le
+          lien d’invitation ne sera disponible qu’une fois la salle créée.
         </p>
         <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
@@ -32,7 +125,61 @@ export default function CreatePage() {
           </div>
         </div>
       </section>
-      <GridEditor />
+
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <label
+            htmlFor="nickname"
+            className="text-sm font-medium text-foreground"
+          >
+            Votre pseudo (partagé avec les autres participants)
+          </label>
+          <input
+            id="nickname"
+            name="nickname"
+            value={nickname}
+            onChange={(event) => {
+              setNickname(event.target.value);
+              setStartError(null);
+            }}
+            onBlur={() => setNicknameTouched(true)}
+            required
+            maxLength={40}
+            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            placeholder="Hôte de la partie"
+            autoComplete="off"
+          />
+          {nicknameTouched && !nickname.trim() ? (
+            <p className="text-sm text-destructive">
+              Un pseudo est requis pour identifier chaque participant.
+            </p>
+          ) : null}
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Ce pseudo sera partagé avec les joueurs et spectateurs via le canal
+          pair-à-pair. Vous pourrez inviter vos amis après avoir lancé la salle.
+        </p>
+      </section>
+
+      <GridEditor ref={gridEditorRef} />
+
+      <section className="space-y-3">
+        {startError ? (
+          <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {startError}
+          </div>
+        ) : null}
+        <Button
+          type="button"
+          size="lg"
+          className="w-full sm:w-auto"
+          onClick={handleStartGame}
+          disabled={isStarting}
+        >
+          {isStarting ? "Création de la salle…" : "Démarrer la partie"}
+        </Button>
+      </section>
     </div>
   );
 }

--- a/src/components/editor/GridEditor.tsx
+++ b/src/components/editor/GridEditor.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { RefreshCcwIcon } from "lucide-react";
 import {
-  AlertCircleIcon,
-  CopyIcon,
-  RefreshCcwIcon,
-  Share2Icon,
-} from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -16,13 +18,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { useToast } from "@/components/ui/use-toast";
 import type { Card as GameCard, Grid } from "@/lib/game/types";
-import { buildInviteUrl, encodeGridToToken } from "@/lib/share/url";
 import {
   type ImageAssetDraft,
   loadGridDraft,
-  type StoredShareState,
   saveGridDraft,
 } from "@/lib/storage/db";
 
@@ -75,235 +74,238 @@ const computeDataUrlBytes = (dataUrl: string): number => {
  * Main grid editor allowing the host to configure board dimensions and cards,
  * preview the layout and generate a shareable invitation link.
  */
-export function GridEditor() {
-  const [gridId, setGridId] = useState(() => createRandomId("grid"));
-  const [gridName, setGridName] = useState("Grille personnalisée");
-  const [rows, setRows] = useState(4);
-  const [columns, setColumns] = useState(4);
-  const [cards, setCards] = useState<GameCard[]>(() => {
-    const total = 4 * 4;
-    return Array.from({ length: total }, (_, index) => createCard(index));
-  });
-  const [shareState, setShareState] = useState<StoredShareState | null>(null);
-  const [shareError, setShareError] = useState<string | null>(null);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [lastSharedSignature, setLastSharedSignature] = useState<string | null>(
-    null,
-  );
-  const [imageMetadata, setImageMetadata] = useState<
-    Record<string, ImageAssetDraft>
-  >({});
-  const [hasRestoredDraft, setHasRestoredDraft] = useState(false);
+export interface GridEditorHandle {
+  /**
+   * Returns the current grid with all inputs normalised (labels trimmed,
+   * fallback identifiers applied). The internal component state is updated to
+   * reflect the normalised values so subsequent renders stay in sync.
+   */
+  commitGrid(): Grid;
+  /** Latest processed metadata for cards backed by locally stored images. */
+  getAssets(): Record<string, ImageAssetDraft>;
+}
 
-  const { toast } = useToast();
+export interface GridEditorProps {
+  /** Optional callback triggered whenever the grid preview object changes. */
+  onGridChange?: (grid: Grid) => void;
+}
 
-  useEffect(() => {
-    const total = rows * columns;
-    setCards((previous) => {
-      if (previous.length === total) {
-        return previous;
-      }
-
-      if (total > previous.length) {
-        const nextCards = [...previous];
-        for (let index = previous.length; index < total; index += 1) {
-          nextCards.push(createCard(index));
-        }
-        return nextCards;
-      }
-
-      return previous.slice(0, total);
+export const GridEditor = forwardRef<GridEditorHandle, GridEditorProps>(
+  ({ onGridChange }, ref) => {
+    const [gridId, setGridId] = useState(() => createRandomId("grid"));
+    const [gridName, setGridName] = useState("Grille personnalisée");
+    const [rows, setRows] = useState(4);
+    const [columns, setColumns] = useState(4);
+    const [cards, setCards] = useState<GameCard[]>(() => {
+      const total = 4 * 4;
+      return Array.from({ length: total }, (_, index) => createCard(index));
     });
-  }, [rows, columns]);
+    const [imageMetadata, setImageMetadata] = useState<
+      Record<string, ImageAssetDraft>
+    >({});
+    const [hasRestoredDraft, setHasRestoredDraft] = useState(false);
 
-  const previewGrid: Grid = useMemo(
-    () => ({
-      id: gridId,
-      name: gridName,
-      rows,
-      columns,
-      cards,
-    }),
-    [gridId, gridName, rows, columns, cards],
-  );
-
-  const signature = useMemo(() => JSON.stringify(previewGrid), [previewGrid]);
-
-  const hasUnsavedChanges =
-    shareState !== null && lastSharedSignature !== signature;
-
-  useEffect(() => {
-    setImageMetadata((previous) => {
-      const activeIds = new Set(cards.map((card) => card.id));
-      let mutated = false;
-      const next: Record<string, ImageAssetDraft> = {};
-      for (const [cardId, metadata] of Object.entries(previous)) {
-        if (activeIds.has(cardId)) {
-          next[cardId] = metadata;
-        } else {
-          mutated = true;
+    useEffect(() => {
+      const total = rows * columns;
+      setCards((previous) => {
+        if (previous.length === total) {
+          return previous;
         }
-      }
-      return mutated ? next : previous;
-    });
-  }, [cards]);
 
-  useEffect(() => {
-    let cancelled = false;
+        if (total > previous.length) {
+          const nextCards = [...previous];
+          for (let index = previous.length; index < total; index += 1) {
+            nextCards.push(createCard(index));
+          }
+          return nextCards;
+        }
 
-    const restoreDraft = async () => {
-      const draft = await loadGridDraft();
-      if (!draft || cancelled) {
-        return;
-      }
+        return previous.slice(0, total);
+      });
+    }, [rows, columns]);
 
-      setGridId(draft.grid.id);
-      setGridName(draft.grid.name);
-      setRows(draft.grid.rows);
-      setColumns(draft.grid.columns);
-      setCards(draft.grid.cards);
-      setShareState(draft.shareState);
-      setLastSharedSignature(draft.lastSharedSignature);
+    const previewGrid: Grid = useMemo(
+      () => ({
+        id: gridId,
+        name: gridName,
+        rows,
+        columns,
+        cards,
+      }),
+      [gridId, gridName, rows, columns, cards],
+    );
 
-      const restoredAssets: Record<string, ImageAssetDraft> = {};
-      const now = Date.now();
-      for (const card of draft.grid.cards) {
+    useEffect(() => {
+      setImageMetadata((previous) => {
+        const activeIds = new Set(cards.map((card) => card.id));
+        let mutated = false;
+        const next: Record<string, ImageAssetDraft> = {};
+        for (const [cardId, metadata] of Object.entries(previous)) {
+          if (activeIds.has(cardId)) {
+            next[cardId] = metadata;
+          } else {
+            mutated = true;
+          }
+        }
+        return mutated ? next : previous;
+      });
+    }, [cards]);
+
+    useEffect(() => {
+      let cancelled = false;
+
+      const restoreDraft = async () => {
+        const draft = await loadGridDraft();
+        if (!draft || cancelled) {
+          return;
+        }
+
+        setGridId(draft.grid.id);
+        setGridName(draft.grid.name);
+        setRows(draft.grid.rows);
+        setColumns(draft.grid.columns);
+        setCards(draft.grid.cards);
+
+        const restoredAssets: Record<string, ImageAssetDraft> = {};
+        const now = Date.now();
+        for (const card of draft.grid.cards) {
+          if (!card.imageUrl || !card.imageUrl.startsWith("data:")) {
+            continue;
+          }
+          const existing = draft.assets[card.id];
+          if (existing) {
+            restoredAssets[card.id] = existing;
+          } else {
+            const bytes = computeDataUrlBytes(card.imageUrl);
+            restoredAssets[card.id] = {
+              cardId: card.id,
+              source: "upload",
+              mimeType: extractMimeTypeFromDataUrl(card.imageUrl),
+              processedBytes: bytes,
+              originalBytes: bytes,
+              createdAt: now,
+            };
+          }
+        }
+        if (!cancelled) {
+          setImageMetadata(restoredAssets);
+        }
+      };
+
+      restoreDraft()
+        .catch((error) => {
+          console.error(
+            "Impossible de restaurer le brouillon précédent.",
+            error,
+          );
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setHasRestoredDraft(true);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, []);
+
+    const filteredAssetMetadata = useMemo(() => {
+      const entries: Record<string, ImageAssetDraft> = {};
+      for (const card of cards) {
         if (!card.imageUrl || !card.imageUrl.startsWith("data:")) {
           continue;
         }
-        const existing = draft.assets[card.id];
-        if (existing) {
-          restoredAssets[card.id] = existing;
-        } else {
-          const bytes = computeDataUrlBytes(card.imageUrl);
-          restoredAssets[card.id] = {
-            cardId: card.id,
-            source: "upload",
-            mimeType: extractMimeTypeFromDataUrl(card.imageUrl),
-            processedBytes: bytes,
-            originalBytes: bytes,
-            createdAt: now,
-          };
+        const metadata = imageMetadata[card.id];
+        if (metadata) {
+          entries[card.id] = metadata;
         }
       }
-      if (!cancelled) {
-        setImageMetadata(restoredAssets);
+      return entries;
+    }, [cards, imageMetadata]);
+
+    useEffect(() => {
+      if (!hasRestoredDraft) {
+        return;
       }
-    };
 
-    restoreDraft()
-      .catch((error) => {
-        console.error("Impossible de restaurer le brouillon précédent.", error);
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setHasRestoredDraft(true);
-        }
-      });
+      const timeout = window.setTimeout(() => {
+        void saveGridDraft({
+          grid: previewGrid,
+          shareState: null,
+          lastSharedSignature: null,
+          assets: filteredAssetMetadata,
+        });
+      }, 400);
 
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const filteredAssetMetadata = useMemo(() => {
-    const entries: Record<string, ImageAssetDraft> = {};
-    for (const card of cards) {
-      if (!card.imageUrl || !card.imageUrl.startsWith("data:")) {
-        continue;
-      }
-      const metadata = imageMetadata[card.id];
-      if (metadata) {
-        entries[card.id] = metadata;
-      }
-    }
-    return entries;
-  }, [cards, imageMetadata]);
-
-  useEffect(() => {
-    if (!hasRestoredDraft) {
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      void saveGridDraft({
-        grid: previewGrid,
-        shareState,
-        lastSharedSignature,
-        assets: filteredAssetMetadata,
-      });
-    }, 400);
-
-    return () => {
-      window.clearTimeout(timeout);
-    };
-  }, [
-    previewGrid,
-    shareState,
-    lastSharedSignature,
-    filteredAssetMetadata,
-    hasRestoredDraft,
-  ]);
-
-  const handleRowsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRows(clampDimension(event.target.valueAsNumber));
-  };
-
-  const handleColumnsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setColumns(clampDimension(event.target.valueAsNumber));
-  };
-
-  const handleCardChange = (index: number, nextCard: GameCard) => {
-    setCards((previous) => {
-      const next = [...previous];
-      next[index] = nextCard;
-      return next;
-    });
-  };
-
-  const handleImageProcessed = (metadata: ImageAssetDraft) => {
-    setImageMetadata((previous) => {
-      const current = previous[metadata.cardId];
-      if (
-        current &&
-        current.mimeType === metadata.mimeType &&
-        current.processedBytes === metadata.processedBytes &&
-        current.originalBytes === metadata.originalBytes &&
-        current.width === metadata.width &&
-        current.height === metadata.height &&
-        current.originalFileName === metadata.originalFileName &&
-        current.originalUrl === metadata.originalUrl &&
-        current.source === metadata.source
-      ) {
-        return previous;
-      }
-      return {
-        ...previous,
-        [metadata.cardId]: metadata,
+      return () => {
+        window.clearTimeout(timeout);
       };
-    });
-  };
+    }, [previewGrid, filteredAssetMetadata, hasRestoredDraft]);
 
-  const handleImageCleared = (cardId: string) => {
-    setImageMetadata((previous) => {
-      if (!(cardId in previous)) {
-        return previous;
+    useEffect(() => {
+      if (typeof onGridChange === "function") {
+        onGridChange(previewGrid);
       }
-      const next = { ...previous };
-      delete next[cardId];
-      return next;
-    });
-  };
+    }, [previewGrid, onGridChange]);
 
-  const regenerateGridId = () => {
-    setGridId(createRandomId("grid"));
-  };
+    const handleRowsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setRows(clampDimension(event.target.valueAsNumber));
+    };
 
-  const handleGenerateLink = () => {
-    setIsGenerating(true);
-    setShareError(null);
+    const handleColumnsChange = (
+      event: React.ChangeEvent<HTMLInputElement>,
+    ) => {
+      setColumns(clampDimension(event.target.valueAsNumber));
+    };
 
-    try {
+    const handleCardChange = (index: number, nextCard: GameCard) => {
+      setCards((previous) => {
+        const next = [...previous];
+        next[index] = nextCard;
+        return next;
+      });
+    };
+
+    const handleImageProcessed = (metadata: ImageAssetDraft) => {
+      setImageMetadata((previous) => {
+        const current = previous[metadata.cardId];
+        if (
+          current &&
+          current.mimeType === metadata.mimeType &&
+          current.processedBytes === metadata.processedBytes &&
+          current.originalBytes === metadata.originalBytes &&
+          current.width === metadata.width &&
+          current.height === metadata.height &&
+          current.originalFileName === metadata.originalFileName &&
+          current.originalUrl === metadata.originalUrl &&
+          current.source === metadata.source
+        ) {
+          return previous;
+        }
+        return {
+          ...previous,
+          [metadata.cardId]: metadata,
+        };
+      });
+    };
+
+    const handleImageCleared = (cardId: string) => {
+      setImageMetadata((previous) => {
+        if (!(cardId in previous)) {
+          return previous;
+        }
+        const next = { ...previous };
+        delete next[cardId];
+        return next;
+      });
+    };
+
+    const regenerateGridId = () => {
+      setGridId(createRandomId("grid"));
+    };
+
+    const buildNormalisedGrid = useCallback((): Grid => {
       const total = rows * columns;
       if (cards.length !== total) {
         throw new Error(
@@ -317,275 +319,183 @@ export function GridEditor() {
         description: card.description?.trim() || undefined,
       }));
 
-      const trimmedGrid: Grid = {
+      return {
         id: normaliseLabel(gridId, createRandomId("grid")),
         name: normaliseLabel(gridName, "Grille personnalisée"),
         rows,
         columns,
         cards: trimmedCards,
-      };
+      } satisfies Grid;
+    }, [cards, columns, gridId, gridName, rows]);
 
-      setGridId(trimmedGrid.id);
-      setGridName(trimmedGrid.name);
-      setCards(trimmedCards);
+    useImperativeHandle(
+      ref,
+      () => ({
+        commitGrid() {
+          const normalised = buildNormalisedGrid();
+          setGridId(normalised.id);
+          setGridName(normalised.name);
+          setCards(normalised.cards);
+          return normalised;
+        },
+        getAssets() {
+          return filteredAssetMetadata;
+        },
+      }),
+      [buildNormalisedGrid, filteredAssetMetadata],
+    );
 
-      const token = encodeGridToToken(trimmedGrid);
-      const origin = window.location.origin;
-      const url = buildInviteUrl(origin, token);
-
-      setShareState({ token, url });
-      setLastSharedSignature(JSON.stringify(trimmedGrid));
-      toast({
-        title: "Lien de partie généré",
-        description:
-          "Partagez ce lien avec votre invité pour charger la grille.",
-      });
-    } catch (error) {
-      setShareError(
-        error instanceof Error
-          ? error.message
-          : "Une erreur inattendue est survenue lors de la génération du lien.",
-      );
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const handleCopyLink = async () => {
-    if (!shareState?.url) {
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(shareState.url);
-      toast({
-        title: "Lien copié",
-        description:
-          "L’URL d’invitation est disponible dans votre presse-papier.",
-      });
-    } catch (error) {
-      setShareError(
-        error instanceof Error
-          ? error.message
-          : "Impossible de copier le lien automatiquement.",
-      );
-    }
-  };
-
-  return (
-    <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-      <div className="space-y-8">
-        <Card className="border border-border/70">
-          <CardHeader>
-            <CardTitle>Paramètres de la grille</CardTitle>
-            <CardDescription>
-              Ajustez les dimensions et l’identifiant avant de configurer les
-              cartes.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="grid gap-6 md:grid-cols-2">
-              <div className="space-y-2">
-                <label
-                  htmlFor="grid-name"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Nom de la grille
-                </label>
-                <input
-                  id="grid-name"
-                  type="text"
-                  value={gridName}
-                  onChange={(event) => setGridName(event.target.value)}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  placeholder="Tournoi d’entraînement"
-                />
-              </div>
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
+    return (
+      <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-8">
+          <Card className="border border-border/70">
+            <CardHeader>
+              <CardTitle>Paramètres de la grille</CardTitle>
+              <CardDescription>
+                Ajustez les dimensions et l’identifiant avant de configurer les
+                cartes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-2">
                   <label
-                    htmlFor="grid-id"
+                    htmlFor="grid-name"
                     className="text-sm font-medium text-foreground"
                   >
-                    Identifiant technique
+                    Nom de la grille
                   </label>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={regenerateGridId}
-                    className="h-8 px-2 text-xs"
-                  >
-                    <RefreshCcwIcon
-                      aria-hidden="true"
-                      className="mr-1 size-3.5"
-                    />
-                    Régénérer
-                  </Button>
-                </div>
-                <input
-                  id="grid-id"
-                  type="text"
-                  value={gridId}
-                  onChange={(event) => setGridId(event.target.value)}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  placeholder="grid-tournoi"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Cet identifiant est inclus dans le lien partagé et permet de
-                  reconnaître la grille.
-                </p>
-              </div>
-            </div>
-            <div className="grid gap-6 md:grid-cols-2">
-              <div className="space-y-2">
-                <label
-                  htmlFor="grid-rows"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Nombre de lignes
-                </label>
-                <input
-                  id="grid-rows"
-                  type="number"
-                  min={MIN_DIMENSION}
-                  max={MAX_DIMENSION}
-                  value={rows}
-                  onChange={handleRowsChange}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              </div>
-              <div className="space-y-2">
-                <label
-                  htmlFor="grid-columns"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Nombre de colonnes
-                </label>
-                <input
-                  id="grid-columns"
-                  type="number"
-                  min={MIN_DIMENSION}
-                  max={MAX_DIMENSION}
-                  value={columns}
-                  onChange={handleColumnsChange}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              </div>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              La grille contiendra {rows * columns} cartes. Ajustez ensuite
-              chaque carte pour personnaliser les avatars.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card className="border border-border/70">
-          <CardHeader>
-            <CardTitle>Cartes du plateau</CardTitle>
-            <CardDescription>
-              Définissez le nom et l’illustration de chaque carte. Les images en
-              data URI augmentent la taille du lien : privilégiez les URLs
-              publiques lorsque c’est possible.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid gap-4 lg:grid-cols-2">
-              {cards.map((card, index) => (
-                <CardEditorItem
-                  key={card.id}
-                  card={card}
-                  index={index}
-                  assetMetadata={imageMetadata[card.id]}
-                  onChange={(nextCard) => handleCardChange(index, nextCard)}
-                  onImageProcessed={handleImageProcessed}
-                  onImageCleared={handleImageCleared}
-                />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="space-y-8">
-        <Card className="border border-border/70">
-          <CardHeader>
-            <CardTitle>Aperçu</CardTitle>
-            <CardDescription>
-              Vérifiez le rendu final tel qu’il sera affiché aux joueurs.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <GridPreview grid={previewGrid} />
-          </CardContent>
-        </Card>
-
-        <Card className="border border-border/70">
-          <CardHeader>
-            <CardTitle>Lien d’invitation</CardTitle>
-            <CardDescription>
-              Générez un lien compressé contenant la configuration de la grille.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Button
-              type="button"
-              size="lg"
-              onClick={handleGenerateLink}
-              disabled={isGenerating}
-              className="w-full"
-            >
-              <Share2Icon aria-hidden="true" className="mr-2 size-4" />
-              {isGenerating
-                ? "Génération en cours…"
-                : "Créer le lien d’invitation"}
-            </Button>
-            {shareError ? (
-              <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                <AlertCircleIcon aria-hidden="true" className="mt-0.5 size-4" />
-                <span>{shareError}</span>
-              </div>
-            ) : null}
-            {shareState ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between text-xs uppercase text-muted-foreground">
-                  <span>URL générée</span>
-                  {hasUnsavedChanges ? (
-                    <span className="font-medium text-amber-600">
-                      Modifications non partagées
-                    </span>
-                  ) : null}
-                </div>
-                <div className="flex gap-2">
                   <input
-                    type="url"
-                    readOnly
-                    value={shareState.url}
-                    className="flex-1 cursor-text rounded-md border border-border/70 bg-muted/50 px-3 py-2 text-sm"
+                    id="grid-name"
+                    type="text"
+                    value={gridName}
+                    onChange={(event) => setGridName(event.target.value)}
+                    className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    placeholder="Tournoi d’entraînement"
                   />
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={handleCopyLink}
-                    className="shrink-0"
-                  >
-                    <CopyIcon aria-hidden="true" className="mr-2 size-4" />
-                    Copier
-                  </Button>
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  Le destinataire doit ouvrir ce lien sur la page « Rejoindre ».
-                  Le fragment (#token) contient la grille compressée.
-                </p>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="grid-id"
+                      className="text-sm font-medium text-foreground"
+                    >
+                      Identifiant technique
+                    </label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={regenerateGridId}
+                      className="h-8 px-2 text-xs"
+                    >
+                      <RefreshCcwIcon
+                        aria-hidden="true"
+                        className="mr-1 size-3.5"
+                      />
+                      Régénérer
+                    </Button>
+                  </div>
+                  <input
+                    id="grid-id"
+                    type="text"
+                    value={gridId}
+                    onChange={(event) => setGridId(event.target.value)}
+                    className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    placeholder="grid-tournoi"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Cet identifiant est inclus dans le lien partagé et permet de
+                    reconnaître la grille.
+                  </p>
+                </div>
               </div>
-            ) : (
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label
+                    htmlFor="grid-rows"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Nombre de lignes
+                  </label>
+                  <input
+                    id="grid-rows"
+                    type="number"
+                    min={MIN_DIMENSION}
+                    max={MAX_DIMENSION}
+                    value={rows}
+                    onChange={handleRowsChange}
+                    className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label
+                    htmlFor="grid-columns"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Nombre de colonnes
+                  </label>
+                  <input
+                    id="grid-columns"
+                    type="number"
+                    min={MIN_DIMENSION}
+                    max={MAX_DIMENSION}
+                    value={columns}
+                    onChange={handleColumnsChange}
+                    className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                </div>
+              </div>
               <p className="text-sm text-muted-foreground">
-                Générez un lien pour partager instantanément la configuration
-                avec votre invité.
+                La grille contiendra {rows * columns} cartes. Ajustez ensuite
+                chaque carte pour personnaliser les avatars.
               </p>
-            )}
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+
+          <Card className="border border-border/70">
+            <CardHeader>
+              <CardTitle>Cartes du plateau</CardTitle>
+              <CardDescription>
+                Définissez le nom et l’illustration de chaque carte. Les images
+                en data URI augmentent la taille du lien : privilégiez les URLs
+                publiques lorsque c’est possible.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 lg:grid-cols-2">
+                {cards.map((card, index) => (
+                  <CardEditorItem
+                    key={card.id}
+                    card={card}
+                    index={index}
+                    assetMetadata={imageMetadata[card.id]}
+                    onChange={(nextCard) => handleCardChange(index, nextCard)}
+                    onImageProcessed={handleImageProcessed}
+                    onImageCleared={handleImageCleared}
+                  />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-8">
+          <Card className="border border-border/70">
+            <CardHeader>
+              <CardTitle>Aperçu</CardTitle>
+              <CardDescription>
+                Vérifiez le rendu final tel qu’il sera affiché aux joueurs.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <GridPreview grid={previewGrid} />
+            </CardContent>
+          </Card>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);
+
+GridEditor.displayName = "GridEditor";

--- a/src/lib/storage/session.ts
+++ b/src/lib/storage/session.ts
@@ -1,0 +1,106 @@
+import type { Grid } from "@/lib/game/types";
+import type { ImageAssetDraft } from "@/lib/storage/db";
+
+const HOST_SESSION_PREFIX = "cki:host-session:";
+
+const isBrowser = typeof window !== "undefined";
+
+const createStorageKey = (roomId: string): string =>
+  `${HOST_SESSION_PREFIX}${roomId}`;
+
+export interface HostPreparationRecord {
+  roomId: string;
+  nickname: string;
+  grid: Grid;
+  assets: Record<string, ImageAssetDraft>;
+  createdAt: number;
+}
+
+export const persistHostPreparation = (
+  record: Omit<HostPreparationRecord, "createdAt">,
+): void => {
+  if (!isBrowser) {
+    throw new Error(
+      "Persisting a host session is only supported in the browser",
+    );
+  }
+
+  const payload: HostPreparationRecord = {
+    ...record,
+    createdAt: Date.now(),
+  };
+
+  try {
+    const key = createStorageKey(record.roomId);
+    window.localStorage.setItem(key, JSON.stringify(payload));
+  } catch (error) {
+    console.error("Impossible d'enregistrer la préparation de partie.", error);
+    throw error;
+  }
+};
+
+export const loadHostPreparation = (
+  roomId: string,
+): HostPreparationRecord | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const key = createStorageKey(roomId);
+  const raw = window.localStorage.getItem(key);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as HostPreparationRecord;
+    if (!parsed || parsed.roomId !== roomId) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.error("Impossible de lire la préparation de partie.", error);
+    return null;
+  }
+};
+
+export const clearHostPreparation = (roomId: string): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    const key = createStorageKey(roomId);
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    console.error("Impossible de supprimer la préparation de partie.", error);
+  }
+};
+
+const NICKNAME_KEY = "cki:nickname:last-used";
+
+export const loadLatestNickname = (): string | null => {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const nickname = window.localStorage.getItem(NICKNAME_KEY);
+  return nickname ? nickname : null;
+};
+
+export const persistLatestNickname = (nickname: string): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    const trimmed = nickname.trim();
+    if (trimmed) {
+      window.localStorage.setItem(NICKNAME_KEY, trimmed);
+    } else {
+      window.localStorage.removeItem(NICKNAME_KEY);
+    }
+  } catch (error) {
+    console.error("Impossible d'enregistrer le pseudo localement.", error);
+  }
+};


### PR DESCRIPTION
## Summary
- require a nickname on the create screen and expose a Start Game CTA that commits the grid draft
- refactor the grid editor to focus on board configuration and surface a handle for retrieving the normalised grid
- persist the host preparation (grid, nickname, assets) in local storage when creating a room

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d06613f4dc832a92e1b48a06a1a2ea