### PR TITLE
Add random grid generation to grid editor

### DIFF
--- a/src/components/editor/GridEditor.tsx
+++ b/src/components/editor/GridEditor.tsx
@@ -18,6 +18,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  createRandomSeed,
+  generateRandomCards,
+} from "@/lib/game/random-characters";
 import type { Card as GameCard, Grid } from "@/lib/game/types";
 import {
   type ImageAssetDraft,
@@ -298,6 +302,22 @@ export const GridEditor = forwardRef<GridEditorHandle, GridEditorProps>(
       setGridId(createRandomId("grid"));
     };
 
+    const handleGenerateRandomGrid = useCallback(() => {
+      const seed = createRandomSeed();
+      setCards((previousCards) => {
+        if (previousCards.length === 0) {
+          return previousCards;
+        }
+        return generateRandomCards({
+          cards: previousCards,
+          seed,
+        });
+      });
+      // Drop any processed image metadata because random avatars rely on
+      // remote URLs rather than locally optimised assets.
+      setImageMetadata(() => ({}));
+    }, []);
+
     const buildNormalisedGrid = useCallback((): Grid => {
       const total = rows * columns;
       if (cards.length !== total) {
@@ -447,13 +467,23 @@ export const GridEditor = forwardRef<GridEditorHandle, GridEditorProps>(
           </Card>
 
           <Card className="border border-border/70">
-            <CardHeader>
-              <CardTitle>Cartes du plateau</CardTitle>
-              <CardDescription>
-                Définissez le nom et l’illustration de chaque carte. Les images
-                en data URI augmentent la taille du lien : privilégiez les URLs
-                publiques lorsque c’est possible.
-              </CardDescription>
+            <CardHeader className="space-y-3 sm:flex sm:items-start sm:justify-between sm:space-y-0 sm:gap-4">
+              <div className="space-y-1">
+                <CardTitle>Cartes du plateau</CardTitle>
+                <CardDescription>
+                  Définissez le nom et l’illustration de chaque carte. Les
+                  images en data URI augmentent la taille du lien : privilégiez
+                  les URLs publiques lorsque c’est possible.
+                </CardDescription>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full sm:w-auto"
+                onClick={handleGenerateRandomGrid}
+              >
+                Generate Random Grid
+              </Button>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-4 lg:grid-cols-2">

--- a/src/lib/game/random-characters.ts
+++ b/src/lib/game/random-characters.ts
@@ -1,0 +1,100 @@
+import { base, en, Faker } from "@faker-js/faker";
+
+import type { Card } from "./types";
+
+/** Supported genders for the random avatar generator. */
+export type RandomAvatarGender = "male" | "female";
+
+const AVATAR_BASE_URL = "https://xsgames.co/randomusers/assets/avatars";
+const MIN_AVATAR_ID = 1;
+const MAX_AVATAR_ID = 60;
+
+const createSeededFaker = (seed: number): Faker => {
+  const fakerInstance = new Faker({
+    locale: [en, base],
+  });
+  fakerInstance.seed(seed);
+  return fakerInstance;
+};
+
+const createDeterministicRng = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let result = Math.imul(state ^ (state >>> 15), state | 1);
+    result ^= result + Math.imul(result ^ (result >>> 7), result | 61);
+    return ((result ^ (result >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const normaliseSeed = (seed: number): number => {
+  if (!Number.isFinite(seed)) {
+    return 1;
+  }
+  const normalised = Math.abs(Math.floor(seed)) >>> 0;
+  return normalised === 0 ? 1 : normalised;
+};
+
+const pickAvatarId = (random: () => number): number => {
+  const span = MAX_AVATAR_ID - MIN_AVATAR_ID + 1;
+  return MIN_AVATAR_ID + Math.floor(random() * span);
+};
+
+const pickAvatarGender = (random: () => number): RandomAvatarGender =>
+  random() < 0.5 ? "male" : "female";
+
+const buildAvatarUrl = (gender: RandomAvatarGender, avatarId: number): string =>
+  `${AVATAR_BASE_URL}/${gender}/${avatarId}.jpg`;
+
+/**
+ * Generates a cryptographically strong seed when available, falling back to a
+ * Math.random-based value otherwise. The returned number is normalised to be
+ * strictly positive because the deterministic generator does not accept 0.
+ */
+export const createRandomSeed = (): number => {
+  if (typeof crypto !== "undefined" && "getRandomValues" in crypto) {
+    const buffer = new Uint32Array(1);
+    crypto.getRandomValues(buffer);
+    const [value] = buffer;
+    return normaliseSeed(value);
+  }
+  return normaliseSeed(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
+};
+
+export interface GenerateRandomCardsOptions {
+  cards: ReadonlyArray<Card>;
+  seed: number;
+}
+
+/**
+ * Produces a new set of cards with randomised avatars and first names.
+ *
+ * The randomness is deterministic for a given seed: invoking the function
+ * twice with the same arguments will yield identical results. Each card keeps
+ * its original identifier so that downstream references remain stable.
+ */
+export const generateRandomCards = ({
+  cards,
+  seed,
+}: GenerateRandomCardsOptions): Card[] => {
+  if (cards.length === 0) {
+    return [];
+  }
+
+  const normalisedSeed = normaliseSeed(seed);
+  const fakerInstance = createSeededFaker(normalisedSeed);
+  const random = createDeterministicRng(normalisedSeed);
+
+  return cards.map((card) => {
+    const gender = pickAvatarGender(random);
+    const avatarId = pickAvatarId(random);
+    const name = fakerInstance.person.firstName(gender);
+
+    return {
+      ...card,
+      label: name,
+      imageUrl: buildAvatarUrl(gender, avatarId),
+      description: undefined,
+    } satisfies Card;
+  });
+};


### PR DESCRIPTION
## Summary
- add a "Generate Random Grid" action to the grid editor UI and clear stale asset metadata when it is used
- implement a seeded random character generator that fetches avatars from XSGames and first names from Faker

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d113dbf598832a94716fbdafef7147