### PR TITLE
Fix invite link flow for room guests

### DIFF
--- a/src/lib/share/url.test.ts
+++ b/src/lib/share/url.test.ts
@@ -43,9 +43,15 @@ describe("share/url", () => {
 
   it("builds a proper invite URL", () => {
     const token = "abc";
-    const url = buildInviteUrl("https://example.com", token);
+    const url = buildInviteUrl(
+      "https://example.com",
+      { roomId: "room-123", hostId: "player-host", hostName: "Alice" },
+      token,
+    );
 
-    expect(url).toBe("https://example.com/join#abc");
+    expect(url).toBe(
+      "https://example.com/room/room-123?hostId=player-host&hostName=Alice&role=guest#abc",
+    );
   });
 
   it("extracts tokens from URLs or raw values", () => {

--- a/src/lib/share/url.ts
+++ b/src/lib/share/url.ts
@@ -78,9 +78,29 @@ export function decodeGridFromToken(token: string): ShareableGridPayload {
  * Builds a full invite URL including the `#/token` fragment.
  * The origin is normalised to avoid accidental double slashes.
  */
-export function buildInviteUrl(origin: string, token: string): string {
+export interface InviteMetadata {
+  roomId: string;
+  hostId: string;
+  hostName: string;
+}
+
+export function buildInviteUrl(
+  origin: string,
+  metadata: InviteMetadata,
+  token: string,
+): string {
   const trimmedOrigin = origin.replace(/\/$/, "");
-  return `${trimmedOrigin}/join#${token}`;
+  const url = new URL(
+    `${trimmedOrigin}/room/${encodeURIComponent(metadata.roomId)}`,
+  );
+  url.searchParams.set("hostId", metadata.hostId);
+  const hostName = metadata.hostName.trim();
+  if (hostName) {
+    url.searchParams.set("hostName", hostName);
+  }
+  url.searchParams.set("role", "guest");
+  url.hash = token;
+  return url.toString();
 }
 
 /**


### PR DESCRIPTION
## Summary
- include the room identifier and host metadata in generated invite URLs and update the share URL tests
- allow the room page to decode invite tokens when no host preparation exists so invitees can view the grid and join as guests
- adjust the invitation card to disable sharing for spectators and surface a guest join form in the room UI

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1189191a4832aa901ddcfc669921d