### PR TITLE
Refactor room layout for full-height responsive boards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,7 @@
     @apply bg-background text-foreground;
   }
 }
+
+.page-shell:has(> .full-height-page) {
+  padding-bottom: 0;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -75,9 +75,11 @@ export default function RootLayout({
             <Header />
             <main
               id="main-content"
-              className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 pb-36 pt-6 md:px-6 md:pb-12"
+              className="mx-auto flex w-full max-w-6xl flex-1 min-h-0 flex-col px-4 pt-6 md:px-6"
             >
-              {children}
+              <div className="page-shell flex flex-1 flex-col gap-8 pb-36 md:pb-12">
+                {children}
+              </div>
             </main>
             <footer className="border-t border-border/70 bg-background/95">
               <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between md:px-6">


### PR DESCRIPTION
## Summary
- allow the global layout to host full-height templates through a shared page-shell wrapper
- replace inline cards on the room page with invitation, participants, and information dialogs and reorganize the header summary
- rebuild the room board area as a responsive full-height flex layout and update player boards to use the available space

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12a4d27b4832ab0c3de7854ae2fa8