### PR TITLE
Integrate peer-to-peer action synchronisation

### DIFF
--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -17,6 +17,7 @@ import {
   type Grid,
   PlayerRole,
   type PlayingState,
+  type Action,
 } from "./types";
 
 const createGrid = (): Grid => ({
@@ -102,6 +103,26 @@ describe("reduceGameState", () => {
         payload: { player: { id: guestId, name: "Guest Again" } },
       }),
     ).toThrow(InvalidGameActionError);
+  });
+
+  it("rejects identical join lobby payloads applied twice", () => {
+    const lobby = reduceGameState(createInitialState(), {
+      type: "game/createLobby",
+      payload: {
+        grid: createGrid(),
+        host: { id: hostId, name: "Host", role: PlayerRole.Host },
+      },
+    });
+    const joinAction = {
+      type: "game/joinLobby" as const,
+      payload: { player: { id: guestId, name: "Guest", role: PlayerRole.Guest } },
+    } satisfies Extract<Action, { type: "game/joinLobby" }>;
+
+    const withGuest = reduceGameState(lobby, joinAction);
+
+    expect(() => reduceGameState(withGuest, joinAction)).toThrow(
+      InvalidGameActionError,
+    );
   });
 
   it("rejects more than two players in a lobby", () => {

--- a/src/lib/p2p/action-sync.test.ts
+++ b/src/lib/p2p/action-sync.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+
+import { createActionReplicator } from "./action-sync";
+import { PeerRole } from "./peer";
+import { createInitialState, reduceGameState } from "../game/state";
+import type { Action, GameState, Grid } from "../game/types";
+import { GameStatus, PlayerRole } from "../game/types";
+import type { GameActionMessagePayload } from "./protocol";
+
+const hostId = "host-player";
+const guestId = "guest-player";
+
+const createGrid = (): Grid => ({
+  id: "grid-1",
+  name: "Test Grid",
+  rows: 2,
+  columns: 2,
+  cards: [
+    { id: "card-a", label: "Alpha" },
+    { id: "card-b", label: "Beta" },
+    { id: "card-c", label: "Gamma" },
+    { id: "card-d", label: "Delta" },
+  ],
+});
+
+const createHostLobby = (): GameState =>
+  reduceGameState(createInitialState(), {
+    type: "game/createLobby",
+    payload: {
+      grid: createGrid(),
+      host: { id: hostId, name: "Host", role: PlayerRole.Host },
+    },
+  });
+
+describe("createActionReplicator", () => {
+  it("applies host actions locally and emits acknowledgements", () => {
+    const sent: GameActionMessagePayload[] = [];
+    const applied: Action[] = [];
+
+    const replicator = createActionReplicator({
+      role: PeerRole.Host,
+      localPeerId: "peer-host",
+      send: (payload) => {
+        sent.push(payload);
+      },
+      onApply: (action) => {
+        applied.push(action);
+      },
+    });
+
+    const action: Action = { type: "game/reset" };
+    const result = replicator.dispatch(action);
+
+    expect(result.appliedLocally).toBe(true);
+    expect(result.deferred).toBe(false);
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toEqual(action);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      acknowledgedByHost: true,
+      issuerPeerId: "peer-host",
+      issuerRole: PeerRole.Host,
+    });
+  });
+
+  it("defers guest lobby joins until the host acknowledges the action", () => {
+    const sent: GameActionMessagePayload[] = [];
+    const applied: Action[] = [];
+    const acknowledgements: string[] = [];
+
+    const replicator = createActionReplicator({
+      role: PeerRole.Guest,
+      localPeerId: "peer-guest",
+      send: (payload) => {
+        sent.push(payload);
+      },
+      shouldDeferLocalApplication: (action) => action.type === "game/joinLobby",
+      onApply: (action) => {
+        applied.push(action);
+      },
+      onAcknowledged: (actionId) => {
+        acknowledgements.push(actionId);
+      },
+    });
+
+    const joinAction: Action = {
+      type: "game/joinLobby",
+      payload: { player: { id: guestId, name: "Guest" } },
+    };
+
+    const result = replicator.dispatch(joinAction);
+    expect(result.appliedLocally).toBe(false);
+    expect(result.deferred).toBe(true);
+    expect(applied).toHaveLength(0);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      acknowledgedByHost: false,
+      issuerRole: PeerRole.Guest,
+    });
+
+    const acknowledgement: GameActionMessagePayload = {
+      ...sent[0],
+      acknowledgedByHost: true,
+      relayedByPeerId: "peer-host",
+    };
+    const remoteResult = replicator.handleRemote(acknowledgement);
+
+    expect(remoteResult.applied).toBe(true);
+    expect(applied).toHaveLength(1);
+    expect(acknowledgements).toContain(sent[0].actionId);
+    expect(replicator.hasPending(sent[0].actionId)).toBe(false);
+  });
+
+  it("acknowledges guest actions exactly once", () => {
+    const hostSent: GameActionMessagePayload[] = [];
+    const applied: Action[] = [];
+
+    const hostReplicator = createActionReplicator({
+      role: PeerRole.Host,
+      localPeerId: "peer-host",
+      send: (payload) => {
+        hostSent.push(payload);
+      },
+      onApply: (action) => {
+        applied.push(action);
+      },
+    });
+
+    const joinPayload: GameActionMessagePayload = {
+      actionId: "action-1",
+      action: {
+        type: "game/joinLobby",
+        payload: { player: { id: guestId, name: "Guest" } },
+      },
+      issuerPeerId: "peer-guest",
+      issuerRole: PeerRole.Guest,
+      acknowledgedByHost: false,
+    };
+
+    const firstResult = hostReplicator.handleRemote(joinPayload);
+    expect(firstResult.applied).toBe(true);
+    expect(applied).toHaveLength(1);
+    expect(hostSent).toHaveLength(1);
+    expect(hostSent[0]).toMatchObject({
+      actionId: joinPayload.actionId,
+      acknowledgedByHost: true,
+      relayedByPeerId: "peer-host",
+    });
+
+    const duplicateResult = hostReplicator.handleRemote(joinPayload);
+    expect(duplicateResult.applied).toBe(false);
+    expect(hostSent).toHaveLength(2);
+    expect(hostSent[1]).toMatchObject({
+      actionId: joinPayload.actionId,
+      acknowledgedByHost: true,
+    });
+  });
+});
+
+describe("action replication integration", () => {
+  it("synchronises a join action between host and guest", () => {
+    let hostState = createHostLobby();
+    let guestState = hostState;
+
+    const hostOutbox: GameActionMessagePayload[] = [];
+    const guestOutbox: GameActionMessagePayload[] = [];
+    const acknowledgements = new Set<string>();
+
+    const hostReplicator = createActionReplicator({
+      role: PeerRole.Host,
+      localPeerId: "peer-host",
+      send: (payload) => {
+        hostOutbox.push(payload);
+      },
+      onApply: (action) => {
+        hostState = reduceGameState(hostState, action);
+      },
+    });
+
+    const guestReplicator = createActionReplicator({
+      role: PeerRole.Guest,
+      localPeerId: "peer-guest",
+      send: (payload) => {
+        guestOutbox.push(payload);
+      },
+      shouldDeferLocalApplication: (action) => action.type === "game/joinLobby",
+      onApply: (action) => {
+        guestState = reduceGameState(guestState, action);
+      },
+      onAcknowledged: (actionId) => {
+        acknowledgements.add(actionId);
+      },
+    });
+
+    const joinAction: Action = {
+      type: "game/joinLobby",
+      payload: { player: { id: guestId, name: "Guest" } },
+    };
+
+    const dispatchResult = guestReplicator.dispatch(joinAction);
+    expect(dispatchResult.deferred).toBe(true);
+    expect(guestOutbox).toHaveLength(1);
+    expect(guestState.players).toHaveLength(1);
+
+    const guestMessage = guestOutbox.shift();
+    expect(guestMessage).toBeDefined();
+    if (!guestMessage) {
+      throw new Error("Guest message was not produced");
+    }
+
+    const hostResult = hostReplicator.handleRemote(guestMessage);
+    expect(hostResult.applied).toBe(true);
+    expect(hostState.status).toBe(GameStatus.Lobby);
+    expect(hostState.players).toHaveLength(2);
+    expect(hostOutbox).toHaveLength(1);
+
+    const acknowledgement = hostOutbox.shift();
+    expect(acknowledgement).toBeDefined();
+    if (!acknowledgement) {
+      throw new Error("Host acknowledgement missing");
+    }
+
+    const guestResult = guestReplicator.handleRemote(acknowledgement);
+    expect(guestResult.applied).toBe(true);
+    expect(guestState.players).toHaveLength(2);
+    expect(acknowledgements.has(acknowledgement.actionId)).toBe(true);
+
+    const duplicateAck = guestReplicator.handleRemote(acknowledgement);
+    expect(duplicateAck.applied).toBe(false);
+  });
+});

--- a/src/lib/p2p/action-sync.ts
+++ b/src/lib/p2p/action-sync.ts
@@ -1,0 +1,189 @@
+import { createRandomId } from "@/lib/utils";
+
+import type { Action } from "../game/types";
+import { PeerRole } from "./peer";
+import type { GameActionMessagePayload } from "./protocol";
+
+type ActionSource = "local" | "remote";
+
+export interface ActionApplicationMetadata {
+  source: ActionSource;
+  acknowledgedByHost: boolean;
+}
+
+export interface ActionErrorContext {
+  action: Action;
+  source: ActionSource;
+}
+
+export interface ActionReplicatorOptions {
+  role: PeerRole;
+  localPeerId: string;
+  send: (payload: GameActionMessagePayload) => void;
+  shouldDeferLocalApplication?: (action: Action) => boolean;
+  onApply: (action: Action, metadata: ActionApplicationMetadata) => void;
+  onError?: (error: Error, context: ActionErrorContext) => void;
+  onAcknowledged?: (actionId: string, payload: GameActionMessagePayload) => void;
+  generateActionId?: () => string;
+}
+
+export interface DispatchResult {
+  actionId: string;
+  appliedLocally: boolean;
+  deferred: boolean;
+}
+
+export interface RemoteProcessResult {
+  actionId: string;
+  applied: boolean;
+  wasDuplicate: boolean;
+  acknowledgedByHost: boolean;
+}
+
+export interface ActionReplicator {
+  dispatch(action: Action): DispatchResult;
+  handleRemote(payload: GameActionMessagePayload): RemoteProcessResult;
+  hasPending(actionId: string): boolean;
+  pendingActionIds(): readonly string[];
+}
+
+const toError = (candidate: unknown): Error => {
+  if (candidate instanceof Error) {
+    return candidate;
+  }
+  return new Error(typeof candidate === "string" ? candidate : "Unknown error");
+};
+
+export const createActionReplicator = (
+  options: ActionReplicatorOptions,
+): ActionReplicator => {
+  const processedIds = new Set<string>();
+  const pending = new Map<string, Action>();
+  const generateActionId =
+    options.generateActionId ?? (() => createRandomId("action"));
+
+  const notifyError = (error: unknown, context: ActionErrorContext) => {
+    const normalised = toError(error);
+    options.onError?.(normalised, context);
+    return normalised;
+  };
+
+  const sendAcknowledgement = (payload: GameActionMessagePayload) => {
+    const acknowledgement: GameActionMessagePayload = {
+      ...payload,
+      acknowledgedByHost: true,
+      relayedByPeerId: options.localPeerId,
+    };
+
+    try {
+      options.send(acknowledgement);
+    } catch (error) {
+      throw notifyError(error, {
+        action: payload.action,
+        source: "remote",
+      });
+    }
+
+    options.onAcknowledged?.(payload.actionId, acknowledgement);
+  };
+
+  const dispatch = (action: Action): DispatchResult => {
+    const actionId = generateActionId();
+    const defer = options.shouldDeferLocalApplication?.(action) ?? false;
+    const acknowledgedByHost = !defer && options.role === PeerRole.Host;
+
+    if (!defer) {
+      try {
+        options.onApply(action, {
+          source: "local",
+          acknowledgedByHost,
+        });
+        processedIds.add(actionId);
+      } catch (error) {
+        throw notifyError(error, { action, source: "local" });
+      }
+    } else {
+      pending.set(actionId, action);
+    }
+
+    const payload: GameActionMessagePayload = {
+      actionId,
+      action,
+      issuerPeerId: options.localPeerId,
+      issuerRole: options.role,
+      acknowledgedByHost,
+    };
+
+    try {
+      options.send(payload);
+    } catch (error) {
+      if (!defer) {
+        processedIds.delete(actionId);
+      } else {
+        pending.delete(actionId);
+      }
+      throw notifyError(error, { action, source: "local" });
+    }
+
+    return { actionId, appliedLocally: !defer, deferred: defer };
+  };
+
+  const handleRemote = (
+    payload: GameActionMessagePayload,
+  ): RemoteProcessResult => {
+    const { actionId, action, acknowledgedByHost } = payload;
+    const alreadyProcessed = processedIds.has(actionId);
+
+    if (alreadyProcessed) {
+      if (acknowledgedByHost) {
+        pending.delete(actionId);
+        options.onAcknowledged?.(actionId, payload);
+      } else if (options.role === PeerRole.Host) {
+        sendAcknowledgement(payload);
+      }
+
+      return {
+        actionId,
+        applied: false,
+        wasDuplicate: true,
+        acknowledgedByHost,
+      };
+    }
+
+    try {
+      options.onApply(action, {
+        source: "remote",
+        acknowledgedByHost,
+      });
+      processedIds.add(actionId);
+    } catch (error) {
+      throw notifyError(error, { action, source: "remote" });
+    }
+
+    if (acknowledgedByHost) {
+      pending.delete(actionId);
+      options.onAcknowledged?.(actionId, payload);
+    } else if (options.role === PeerRole.Host) {
+      sendAcknowledgement(payload);
+    }
+
+    return {
+      actionId,
+      applied: true,
+      wasDuplicate: false,
+      acknowledgedByHost,
+    };
+  };
+
+  const hasPending = (actionId: string): boolean => pending.has(actionId);
+
+  const pendingActionIds = (): readonly string[] => Array.from(pending.keys());
+
+  return {
+    dispatch,
+    handleRemote,
+    hasPending,
+    pendingActionIds,
+  };
+};
+


### PR DESCRIPTION
## Summary
- add a dedicated room peer runtime hook to control PeerRuntime lifecycle and expose connection state
- broadcast reducer actions through the new action replicator, validating remote payloads before mutating state
- version the simplified game protocol and cover action duplication with unit and integration tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d13115d708832a9ed6d2a01e2a2ccd