### PR TITLE
Ensure invite dialog receives join availability flag

### DIFF
--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -287,6 +287,7 @@ function InviteDialog({
   host,
   canShare,
   allowJoin,
+  canJoinAsPlayer,
   onJoin,
   isJoining,
 }: {
@@ -295,6 +296,7 @@ function InviteDialog({
   host: HostIdentitySummary | null;
   canShare: boolean;
   allowJoin: boolean;
+  canJoinAsPlayer: boolean;
   onJoin: (nickname: string) => void;
   isJoining: boolean;
 }) {
@@ -401,6 +403,7 @@ function InviteDialog({
     ? "Erreur lors de la génération du lien"
     : "Le lien apparaîtra ici dès qu’il est prêt.";
   const hostName = host?.name ?? "Hôte";
+  const isSubmitting = isJoining;
 
   return (
     <Dialog>

--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -11,13 +11,13 @@ import {
   selectWinner,
 } from "./state";
 import {
+  type Action,
   GameConclusionReason,
   type GameState,
   GameStatus,
   type Grid,
   PlayerRole,
   type PlayingState,
-  type Action,
 } from "./types";
 
 const createGrid = (): Grid => ({
@@ -115,7 +115,9 @@ describe("reduceGameState", () => {
     });
     const joinAction = {
       type: "game/joinLobby" as const,
-      payload: { player: { id: guestId, name: "Guest", role: PlayerRole.Guest } },
+      payload: {
+        player: { id: guestId, name: "Guest", role: PlayerRole.Guest },
+      },
     } satisfies Extract<Action, { type: "game/joinLobby" }>;
 
     const withGuest = reduceGameState(lobby, joinAction);

--- a/src/lib/p2p/action-sync.test.ts
+++ b/src/lib/p2p/action-sync.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { createActionReplicator } from "./action-sync";
-import { PeerRole } from "./peer";
 import { createInitialState, reduceGameState } from "../game/state";
 import type { Action, GameState, Grid } from "../game/types";
 import { GameStatus, PlayerRole } from "../game/types";
+import { createActionReplicator } from "./action-sync";
+import { PeerRole } from "./peer";
 import type { GameActionMessagePayload } from "./protocol";
 
 const hostId = "host-player";

--- a/src/lib/p2p/action-sync.ts
+++ b/src/lib/p2p/action-sync.ts
@@ -23,7 +23,10 @@ export interface ActionReplicatorOptions {
   shouldDeferLocalApplication?: (action: Action) => boolean;
   onApply: (action: Action, metadata: ActionApplicationMetadata) => void;
   onError?: (error: Error, context: ActionErrorContext) => void;
-  onAcknowledged?: (actionId: string, payload: GameActionMessagePayload) => void;
+  onAcknowledged?: (
+    actionId: string,
+    payload: GameActionMessagePayload,
+  ) => void;
   generateActionId?: () => string;
 }
 
@@ -186,4 +189,3 @@ export const createActionReplicator = (
     pendingActionIds,
   };
 };
-

--- a/src/lib/p2p/protocol.ts
+++ b/src/lib/p2p/protocol.ts
@@ -39,14 +39,13 @@ export interface GameProtocolMessageMap {
 
 export type GameProtocolMessageType = keyof GameProtocolMessageMap;
 
-export type GameProtocolMessage<
-  Type extends GameProtocolMessageType,
-> = Type extends keyof GameProtocolMessageMap
-  ? {
-      type: Type;
-      payload: GameProtocolMessageMap[Type];
-    }
-  : never;
+export type GameProtocolMessage<Type extends GameProtocolMessageType> =
+  Type extends keyof GameProtocolMessageMap
+    ? {
+        type: Type;
+        payload: GameProtocolMessageMap[Type];
+      }
+    : never;
 
 export const validateGameActionMessage = (
   payload: unknown,
@@ -57,4 +56,3 @@ export const validateGameActionMessage = (
   }
   return result.data;
 };
-


### PR DESCRIPTION
## Summary
- add the `canJoinAsPlayer` prop to the invite dialog so the guest form logic receives the room capacity state without raising a runtime reference error
- align Biome formatting in the affected test and protocol files to keep linting clean

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d13adc05c0832a9d3fbf1e7593377c