### PR TITLE
Fix worker image transfer error

### DIFF
--- a/src/lib/storage/image-processor.ts
+++ b/src/lib/storage/image-processor.ts
@@ -100,7 +100,9 @@ export const processImage = async (
       reject,
     });
     try {
-      workerInstance.postMessage(request, [blob]);
+      // Les blobs ne font pas partie des objets transférables ;
+      // l’envoi sans liste de transfert évite l’erreur postMessage.
+      workerInstance.postMessage(request);
     } catch (error) {
       pendingRequests.delete(requestId);
       reject(


### PR DESCRIPTION
## Summary
- avoid transferring Blob instances when posting image processing requests to the worker
- document why the transfer list is omitted to prevent postMessage failures

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1443ed364832aa0272c3ec582fc31