### PR TITLE
Refine create page layout and inputs

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -8,6 +8,7 @@ import {
   GridEditor,
   type GridEditorHandle,
 } from "@/components/editor/GridEditor";
+import { NicknameInput } from "@/components/NicknameInput";
 import { Button } from "@/components/ui/button";
 import type { Grid } from "@/lib/game/types";
 import {
@@ -104,89 +105,78 @@ export default function CreatePage() {
   };
 
   return (
-    <div className="flex flex-col gap-10">
-      <section className="space-y-5">
-        <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
-          <SparklesIcon aria-hidden="true" className="size-4" />
-          Configuration de la grille
-        </div>
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-          Créez votre plateau KeyS personnalisé
-        </h1>
-        <p className="text-base text-muted-foreground sm:text-lg">
-          Personnalisez vos cartes depuis l’aperçu interactif puis partagez
-          votre salle en un instant. Le lien d’invitation s’affichera une fois
-          la préparation terminée.
-        </p>
-        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
-          <div className="flex items-center gap-2">
-            <LayoutGridIcon
-              aria-hidden="true"
-              className="size-4 text-primary"
-            />
-            Dimensions dynamiques (2 à 8 cases par côté)
-          </div>
-          <div className="flex items-center gap-2">
-            <ImageIcon aria-hidden="true" className="size-4 text-primary" />
-            Images locales ou via URL publique
-          </div>
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <div className="space-y-2">
-          <label
-            htmlFor="nickname"
-            className="text-sm font-medium text-foreground"
-          >
-            Votre pseudo (partagé avec les autres participants)
-          </label>
-          <input
-            id="nickname"
-            name="nickname"
-            value={nickname}
-            onChange={(event) => {
-              setNickname(event.target.value);
-              setStartError(null);
-            }}
-            onBlur={() => setNicknameTouched(true)}
-            required
-            maxLength={40}
-            className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            placeholder="Hôte de la partie"
-            autoComplete="off"
-          />
-          {nicknameTouched && !nickname.trim() ? (
-            <p className="text-sm text-destructive">
-              Un pseudo est requis pour identifier chaque participant.
+    <div className="flex min-h-svh flex-col bg-background">
+      <main className="flex-1">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-4 pb-24 pt-10 sm:px-6 sm:pb-16 lg:px-8">
+          <section className="space-y-5">
+            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+              <SparklesIcon aria-hidden="true" className="size-4" />
+              Configuration de la grille
+            </div>
+            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+              Créez votre plateau KeyS personnalisé
+            </h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              Personnalisez vos cartes depuis l’aperçu interactif puis partagez
+              votre salle en un instant. Le lien d’invitation s’affichera une
+              fois la préparation terminée.
             </p>
-          ) : null}
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <LayoutGridIcon
+                  aria-hidden="true"
+                  className="size-4 text-primary"
+                />
+                Dimensions dynamiques (2 à 8 cases par côté)
+              </div>
+              <div className="flex items-center gap-2">
+                <ImageIcon aria-hidden="true" className="size-4 text-primary" />
+                Images locales ou via URL publique
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <NicknameInput
+              inputId="nickname"
+              value={nickname}
+              onValueChange={(nextValue) => {
+                setNickname(nextValue);
+                setStartError(null);
+              }}
+              onBlur={() => setNicknameTouched(true)}
+              showValidationFeedback={nicknameTouched}
+              description="Ce pseudo sera visible par les joueurs et les spectateurs pendant la partie. Vous pourrez inviter vos amis après avoir lancé la salle."
+              autoComplete="nickname"
+            />
+          </section>
+
+          <GridEditor ref={gridEditorRef} />
         </div>
+      </main>
 
-        <p className="text-sm text-muted-foreground">
-          Ce pseudo sera visible par les joueurs et les spectateurs pendant la
-          partie. Vous pourrez inviter vos amis après avoir lancé la salle.
-        </p>
-      </section>
-
-      <GridEditor ref={gridEditorRef} />
-
-      <section className="space-y-3">
-        {startError ? (
-          <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {startError}
-          </div>
-        ) : null}
-        <Button
-          type="button"
-          size="lg"
-          className="w-full sm:w-auto"
-          onClick={handleStartGame}
-          disabled={isStarting}
-        >
-          {isStarting ? "Création de la salle…" : "Démarrer la partie"}
-        </Button>
-      </section>
+      <div className="sticky bottom-0 z-20 border-t border-border/70 bg-background/95 px-4 py-4 shadow-[0_-12px_24px_-20px_rgba(15,23,42,0.45)] backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:relative sm:border-t-0 sm:bg-transparent sm:px-6 sm:py-8 sm:shadow-none sm:backdrop-blur-none lg:px-8">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          {startError ? (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive sm:flex-1"
+            >
+              {startError}
+            </div>
+          ) : null}
+          <Button
+            type="button"
+            size="lg"
+            className="w-full sm:w-auto sm:min-w-[14rem]"
+            onClick={handleStartGame}
+            disabled={isStarting}
+          >
+            {isStarting ? "Création de la salle…" : "Démarrer la partie"}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/NicknameInput.tsx
+++ b/src/components/NicknameInput.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { FocusEvent } from "react";
+import { useId, useMemo, useState } from "react";
+
+export interface NicknameInputProps {
+  /** Unique identifier for the input element. */
+  inputId?: string;
+  /** Name attribute for the input element. */
+  name?: string;
+  /** Label displayed above the input. */
+  label?: string;
+  /** Descriptive helper text rendered below the input. */
+  description?: string;
+  /** Placeholder displayed inside the input field. */
+  placeholder?: string;
+  /** Maximum number of characters the nickname accepts. */
+  maxLength?: number;
+  /** Whether the field is required. Defaults to true. */
+  required?: boolean;
+  /** Custom validation message displayed when the value is empty. */
+  requiredMessage?: string;
+  /**
+   * External flag to force the display of the validation message.
+   * Useful when validating on form submission.
+   */
+  showValidationFeedback?: boolean;
+  /** Current nickname value. */
+  value: string;
+  /** Callback executed when the nickname changes. */
+  onValueChange: (value: string) => void;
+  /** Optional blur handler executed after the component tracks focus loss. */
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+  /** Optional focus handler forwarded to the underlying input. */
+  onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
+  /** Optional autocomplete hint. */
+  autoComplete?: string;
+}
+
+const DEFAULT_REQUIRED_MESSAGE =
+  "Un pseudo est requis pour identifier chaque participant.";
+
+/**
+ * Accessible nickname input with inline validation and helper messaging.
+ */
+export function NicknameInput({
+  inputId,
+  name = "nickname",
+  label = "Votre pseudo (partagé avec les autres participants)",
+  description,
+  placeholder = "Hôte de la partie",
+  maxLength = 40,
+  required = true,
+  requiredMessage = DEFAULT_REQUIRED_MESSAGE,
+  showValidationFeedback = false,
+  value,
+  onValueChange,
+  onBlur,
+  onFocus,
+  autoComplete = "off",
+}: NicknameInputProps) {
+  const reactId = useId();
+  const fieldId = inputId ?? reactId;
+  const [hasBlurred, setHasBlurred] = useState(false);
+
+  const trimmedValue = value.trim();
+  const validationMessage = useMemo(() => {
+    if (!required) {
+      return null;
+    }
+    return trimmedValue.length === 0 ? requiredMessage : null;
+  }, [required, requiredMessage, trimmedValue]);
+
+  const showValidationMessage =
+    Boolean(validationMessage) && (showValidationFeedback || hasBlurred);
+
+  const descriptionId = description ? `${fieldId}-description` : undefined;
+  const errorId = showValidationMessage ? `${fieldId}-error` : undefined;
+  const describedByEntries = [errorId, descriptionId].filter(
+    (identifier): identifier is string => Boolean(identifier),
+  );
+  const ariaDescribedBy =
+    describedByEntries.length > 0 ? describedByEntries.join(" ") : undefined;
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={fieldId} className="text-sm font-medium text-foreground">
+        {label}
+      </label>
+      <input
+        id={fieldId}
+        name={name}
+        value={value}
+        onChange={(event) => {
+          onValueChange(event.target.value);
+        }}
+        onBlur={(event) => {
+          setHasBlurred(true);
+          onBlur?.(event);
+        }}
+        onFocus={onFocus}
+        required={required}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-invalid={showValidationMessage}
+        aria-describedby={ariaDescribedBy}
+        autoComplete={autoComplete}
+        inputMode="text"
+        spellCheck={false}
+      />
+      {showValidationMessage ? (
+        <p id={errorId} className="text-sm text-destructive">
+          {validationMessage}
+        </p>
+      ) : null}
+      {description ? (
+        <p id={descriptionId} className="text-sm text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/editor/GridEditor.tsx
+++ b/src/components/editor/GridEditor.tsx
@@ -10,6 +10,12 @@ import {
   useState,
 } from "react";
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -424,60 +430,7 @@ export const GridEditor = forwardRef<GridEditorHandle, GridEditorProps>(
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
-            <div className="grid gap-6 md:grid-cols-2">
-              <div className="space-y-2">
-                <label
-                  htmlFor="grid-name"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Nom de la grille
-                </label>
-                <input
-                  id="grid-name"
-                  type="text"
-                  value={gridName}
-                  onChange={(event) => setGridName(event.target.value)}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  placeholder="Tournoi d’entraînement"
-                />
-              </div>
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="grid-id"
-                    className="text-sm font-medium text-foreground"
-                  >
-                    Identifiant technique
-                  </label>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={regenerateGridId}
-                    className="h-8 px-2 text-xs"
-                  >
-                    <RefreshCcwIcon
-                      aria-hidden="true"
-                      className="mr-1 size-3.5"
-                    />
-                    Régénérer
-                  </Button>
-                </div>
-                <input
-                  id="grid-id"
-                  type="text"
-                  value={gridId}
-                  onChange={(event) => setGridId(event.target.value)}
-                  className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  placeholder="grid-tournoi"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Cet identifiant est intégré au lien partagé et aide à
-                  retrouver la grille.
-                </p>
-              </div>
-            </div>
-            <div className="grid gap-6 md:grid-cols-2">
+            <div className="grid gap-6 sm:grid-cols-2">
               <div className="space-y-2">
                 <label
                   htmlFor="grid-rows"
@@ -513,6 +466,74 @@ export const GridEditor = forwardRef<GridEditorHandle, GridEditorProps>(
                 />
               </div>
             </div>
+            <Accordion
+              type="single"
+              collapsible
+              className="w-full overflow-hidden rounded-md border border-border/70"
+            >
+              <AccordionItem value="advanced" className="border-b-0">
+                <AccordionTrigger className="px-4">
+                  Paramètres avancés
+                </AccordionTrigger>
+                <AccordionContent className="space-y-6 px-4">
+                  <p className="text-sm text-muted-foreground">
+                    Ajustez le nom public et l’identifiant technique si vous
+                    partagez plusieurs configurations.
+                  </p>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="grid-name"
+                      className="text-sm font-medium text-foreground"
+                    >
+                      Nom de la grille
+                    </label>
+                    <input
+                      id="grid-name"
+                      type="text"
+                      value={gridName}
+                      onChange={(event) => setGridName(event.target.value)}
+                      className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      placeholder="Tournoi d’entraînement"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <label
+                        htmlFor="grid-id"
+                        className="text-sm font-medium text-foreground"
+                      >
+                        Identifiant technique
+                      </label>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={regenerateGridId}
+                        className="h-8 px-2 text-xs"
+                      >
+                        <RefreshCcwIcon
+                          aria-hidden="true"
+                          className="mr-1 size-3.5"
+                        />
+                        Régénérer
+                      </Button>
+                    </div>
+                    <input
+                      id="grid-id"
+                      type="text"
+                      value={gridId}
+                      onChange={(event) => setGridId(event.target.value)}
+                      className="w-full rounded-md border border-border/70 bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      placeholder="grid-tournoi"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Cet identifiant est intégré au lien partagé et aide à
+                      retrouver la grille.
+                    </p>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
             <p className="text-sm text-muted-foreground">
               La grille contiendra {rows * columns} cartes. Personnalisez-les en
               cliquant directement sur l’aperçu ci-dessous.


### PR DESCRIPTION
## Summary
- add a reusable `NicknameInput` component with inline validation messaging
- refactor the create page to a single-column flow with a sticky mobile start button
- wrap optional grid settings inside a collapsible advanced section for progressive disclosure

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1532121d0832a93a036dbfef6e17e