### PR TITLE
Allow flipping secret cards on the player board

### DIFF
--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -197,15 +197,20 @@ describe("reduceGameState", () => {
     ).toThrow(InvalidGameActionError);
   });
 
-  it("prevents flipping the secret card", () => {
+  it("allows toggling the secret card on the player board", () => {
     const playing = createPlayingState();
+    const action = {
+      type: "turn/flipCard" as const,
+      payload: { playerId: hostId, cardId: "card-a" },
+    };
 
-    expect(() =>
-      reduceGameState(playing, {
-        type: "turn/flipCard",
-        payload: { playerId: hostId, cardId: "card-a" },
-      }),
-    ).toThrow(InvalidGameActionError);
+    const afterFirstFlip = reduceGameState(playing, action);
+    expect(selectActivePlayer(afterFirstFlip)?.flippedCardIds).toEqual([
+      "card-a",
+    ]);
+
+    const afterSecondFlip = reduceGameState(afterFirstFlip, action);
+    expect(selectActivePlayer(afterSecondFlip)?.flippedCardIds).toEqual([]);
   });
 
   it("allows toggling cards on repeated flips", () => {

--- a/src/lib/game/state.ts
+++ b/src/lib/game/state.ts
@@ -319,12 +319,7 @@ export const reduceGameState = (
         } satisfies PlayingState;
       }
 
-      assert(
-        player.secretCardId !== cardId,
-        action,
-        "A player cannot flip their own secret card",
-      );
-
+      // The secret card remains tracked separately, so allow toggling it on the board.
       const updatedPlayer: Player = {
         ...player,
         flippedCardIds: sortFlippedCards(playingState.grid, [


### PR DESCRIPTION
## Summary
- allow active players to toggle their secret card on the board without triggering an error
- document the behaviour and adjust the unit test suite to cover the updated rule

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1590055a0832abfa52290711a95aa