### PR TITLE
Implement modal secret selection and turn management UI

### DIFF
--- a/src/components/room/ParticipantsSheet.tsx
+++ b/src/components/room/ParticipantsSheet.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import {
+  CrownIcon,
+  EyeIcon,
+  ShieldIcon,
+  UserMinusIcon,
+  UserPlusIcon,
+  UsersIcon,
+} from "lucide-react";
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { Player, PlayerRole } from "@/lib/game/types";
+import { cn } from "@/lib/utils";
+
+type PlayerSummary = {
+  readonly player: Player;
+  readonly ready: boolean;
+  readonly isLocal: boolean;
+  readonly isActive: boolean;
+};
+
+type SpectatorSummary = {
+  readonly id: string;
+  readonly name: string;
+};
+
+type ParticipantsSheetProps = {
+  readonly players: readonly PlayerSummary[];
+  readonly spectators: readonly SpectatorSummary[];
+  readonly statusLabel: string;
+  readonly turnLabel: string;
+  readonly isHost: boolean;
+  readonly canPromoteSpectators: boolean;
+  readonly canKickPlayers: boolean;
+  readonly onPromoteSpectator?: (spectatorId: string) => void;
+  readonly onKickSpectator?: (spectatorId: string) => void;
+  readonly onKickPlayer?: (playerId: string) => void;
+};
+
+const roleLabels: Record<PlayerRole, string> = {
+  host: "Hôte",
+  guest: "Invité",
+};
+
+function PlayerRow({
+  summary,
+  isHost,
+  canKick,
+  onKick,
+}: {
+  summary: PlayerSummary;
+  isHost: boolean;
+  canKick: boolean;
+  onKick?: (playerId: string) => void;
+}) {
+  const { player, ready, isLocal, isActive } = summary;
+  const badgeItems = [
+    ready
+      ? {
+          key: "ready",
+          label: "Prêt",
+          className: "bg-emerald-500/20 text-emerald-600 dark:text-emerald-300",
+        }
+      : {
+          key: "pending",
+          label: "À préparer",
+          className: "border-dashed text-muted-foreground",
+          variant: "outline" as const,
+        },
+    isLocal
+      ? {
+          key: "local",
+          label: "Vous",
+          className: "bg-sky-500/15 text-sky-600 dark:text-sky-300",
+        }
+      : null,
+    isActive
+      ? {
+          key: "active",
+          label: "Tour en cours",
+          className: "bg-primary/15 text-primary",
+        }
+      : null,
+  ].filter(Boolean) as Array<{
+    key: string;
+    label: string;
+    className: string;
+    variant?: "outline";
+  }>;
+
+  return (
+    <li className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/20 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {player.role === "host" ? (
+            <span className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <CrownIcon aria-hidden className="size-4" />
+            </span>
+          ) : (
+            <span className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <UsersIcon aria-hidden className="size-4" />
+            </span>
+          )}
+          <div className="space-y-1">
+            <p className="font-semibold text-foreground">{player.name}</p>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide">
+              {roleLabels[player.role]}
+            </p>
+          </div>
+        </div>
+        {isHost && canKick && onKick ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onKick(player.id)}
+          >
+            <UserMinusIcon aria-hidden className="mr-2 size-4" />
+            Exclure
+          </Button>
+        ) : null}
+      </div>
+      {badgeItems.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {badgeItems.map((badge) => (
+            <Badge
+              key={badge.key}
+              variant={badge.variant}
+              className={cn("text-xs", badge.className)}
+            >
+              {badge.label}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function SpectatorRow({
+  spectator,
+  isHost,
+  canPromote,
+  onPromote,
+  onKick,
+}: {
+  spectator: SpectatorSummary;
+  isHost: boolean;
+  canPromote: boolean;
+  onPromote?: (spectatorId: string) => void;
+  onKick?: (spectatorId: string) => void;
+}) {
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/70 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <span className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <EyeIcon aria-hidden className="size-4" />
+        </span>
+        <div className="space-y-0.5">
+          <p className="font-medium text-foreground">{spectator.name}</p>
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            Spectateur
+          </p>
+        </div>
+      </div>
+      {isHost ? (
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onPromote?.(spectator.id)}
+            disabled={!canPromote || !onPromote}
+          >
+            <UserPlusIcon aria-hidden className="mr-2 size-4" />
+            Promouvoir
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onKick?.(spectator.id)}
+            disabled={!onKick}
+          >
+            <UserMinusIcon aria-hidden className="mr-2 size-4" />
+            Retirer
+          </Button>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function ParticipantsSheet({
+  players,
+  spectators,
+  statusLabel,
+  turnLabel,
+  isHost,
+  canPromoteSpectators,
+  canKickPlayers,
+  onPromoteSpectator,
+  onKickSpectator,
+  onKickPlayer,
+}: ParticipantsSheetProps) {
+  const playerCount = players.length;
+  const hostPlayer = useMemo(
+    () => players.find((summary) => summary.player.role === "host") ?? null,
+    [players],
+  );
+  const guestPlayer = useMemo(
+    () => players.find((summary) => summary.player.role === "guest") ?? null,
+    [players],
+  );
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="flex items-center gap-2"
+        >
+          <UsersIcon aria-hidden className="size-4" />
+          Participants ({playerCount}/2)
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="bottom"
+        className="flex max-h-[88vh] flex-col gap-0 rounded-t-3xl border-l-0 border-t px-0 pb-4 pt-2 sm:max-w-md sm:rounded-none sm:border-l sm:border-t-0 sm:px-0"
+      >
+        <SheetHeader className="border-b px-6 pb-4 pt-2">
+          <SheetTitle className="flex items-center gap-2 text-lg">
+            <ShieldIcon aria-hidden className="size-5 text-primary" />
+            Participants et rôles
+          </SheetTitle>
+          <SheetDescription className="space-y-1 text-sm">
+            <p>Suivez les connexions et gérez les accès à la partie.</p>
+            <p className="text-xs text-muted-foreground">
+              {statusLabel} — {turnLabel}
+            </p>
+          </SheetDescription>
+        </SheetHeader>
+        <ScrollArea className="flex-1 px-6 py-4">
+          <div className="space-y-6 pb-4">
+            <section className="space-y-3">
+              <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <CrownIcon aria-hidden className="size-4" />
+                Hôte
+              </h3>
+              <ul className="space-y-3">
+                {hostPlayer ? (
+                  <PlayerRow
+                    summary={hostPlayer}
+                    isHost={isHost}
+                    canKick={isHost && canKickPlayers}
+                    onKick={onKickPlayer}
+                  />
+                ) : (
+                  <li className="rounded-md border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+                    Aucun hôte connecté actuellement.
+                  </li>
+                )}
+              </ul>
+            </section>
+            <section className="space-y-3">
+              <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <UsersIcon aria-hidden className="size-4" />
+                Invité
+              </h3>
+              <ul className="space-y-3">
+                {guestPlayer ? (
+                  <PlayerRow
+                    summary={guestPlayer}
+                    isHost={isHost}
+                    canKick={isHost && canKickPlayers}
+                    onKick={onKickPlayer}
+                  />
+                ) : (
+                  <li className="rounded-md border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+                    En attente d’un invité.
+                  </li>
+                )}
+              </ul>
+            </section>
+            <section className="space-y-3">
+              <h3 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                <EyeIcon aria-hidden className="size-4" />
+                Spectateurs ({spectators.length})
+              </h3>
+              {spectators.length > 0 ? (
+                <ul className="space-y-2">
+                  {spectators.map((spectator) => (
+                    <SpectatorRow
+                      key={spectator.id}
+                      spectator={spectator}
+                      isHost={isHost}
+                      canPromote={canPromoteSpectators}
+                      onPromote={onPromoteSpectator}
+                      onKick={onKickSpectator}
+                    />
+                  ))}
+                </ul>
+              ) : (
+                <div className="rounded-md border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+                  Aucun spectateur pour le moment.
+                </div>
+              )}
+            </section>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export { ParticipantsSheet };

--- a/src/components/room/TargetSelectionModal.tsx
+++ b/src/components/room/TargetSelectionModal.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { CheckCircle2Icon, ShuffleIcon, TargetIcon } from "lucide-react";
+import {
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { ImageSafe } from "@/components/common/ImageSafe";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { Card as GameCard } from "@/lib/game/types";
+import { cn } from "@/lib/utils";
+
+type TargetSelectionModalProps = {
+  readonly cards: readonly GameCard[];
+  readonly isOpen: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly currentCardId: string | null;
+  readonly playerName: string;
+  readonly onConfirm: (cardId: string) => void;
+};
+
+function getRandomCard(cards: readonly GameCard[]): GameCard | null {
+  if (cards.length === 0) {
+    return null;
+  }
+  const index = Math.floor(Math.random() * cards.length);
+  return cards[index] ?? null;
+}
+
+type SelectableCardProps = {
+  readonly card: GameCard;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+};
+
+function SelectableCard({ card, isSelected, onSelect }: SelectableCardProps) {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onSelect();
+      }
+    },
+    [onSelect],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
+      aria-pressed={isSelected}
+      className={cn(
+        "flex h-full flex-col gap-3 rounded-xl border bg-background/95 p-3 text-left shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isSelected
+          ? "border-primary/70 ring-2 ring-primary/60 ring-offset-2"
+          : "border-border/60 hover:border-border",
+      )}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
+        {card.imageUrl ? (
+          <ImageSafe
+            src={card.imageUrl}
+            alt={card.label}
+            className="absolute inset-0"
+            imageProps={{
+              sizes: "(min-width: 1024px) 240px, (min-width: 768px) 45vw, 80vw",
+            }}
+            fallback={
+              <span className="absolute inset-0 flex items-center justify-center px-3 text-center text-xs text-muted-foreground">
+                Image indisponible
+              </span>
+            }
+          />
+        ) : (
+          <span className="absolute inset-0 flex items-center justify-center px-3 text-center text-xs text-muted-foreground">
+            Aucun visuel
+          </span>
+        )}
+        {isSelected ? (
+          <span className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-primary px-2 py-1 text-xs font-medium text-primary-foreground shadow">
+            <CheckCircle2Icon aria-hidden className="size-3.5" />
+            Sélectionnée
+          </span>
+        ) : null}
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-foreground">{card.label}</p>
+        {card.description ? (
+          <p className="text-xs text-muted-foreground line-clamp-3">
+            {card.description}
+          </p>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+function TargetSelectionModal({
+  cards,
+  isOpen,
+  onOpenChange,
+  currentCardId,
+  playerName,
+  onConfirm,
+}: TargetSelectionModalProps) {
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(
+    currentCardId,
+  );
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setSelectedCardId(currentCardId);
+    setLocalError(null);
+  }, [isOpen, currentCardId]);
+
+  const selectedCard = useMemo(() => {
+    if (!selectedCardId) {
+      return null;
+    }
+    return cards.find((card) => card.id === selectedCardId) ?? null;
+  }, [cards, selectedCardId]);
+
+  const handleSelectCard = useCallback((cardId: string) => {
+    setSelectedCardId(cardId);
+    setLocalError(null);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedCardId) {
+      setLocalError("Sélectionnez une carte avant de confirmer.");
+      return;
+    }
+    onConfirm(selectedCardId);
+  }, [onConfirm, selectedCardId]);
+
+  const handleRandomSelection = useCallback(() => {
+    const randomCard = getRandomCard(cards);
+    if (!randomCard) {
+      setLocalError(
+        "Aucune carte n’est disponible pour la sélection aléatoire.",
+      );
+      return;
+    }
+    setSelectedCardId(randomCard.id);
+    setLocalError(null);
+  }, [cards]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="space-y-2 border-b px-6 py-5">
+          <DialogTitle className="flex items-center gap-2 text-lg">
+            <TargetIcon aria-hidden className="size-5 text-primary" />
+            Choisissez la carte secrète de {playerName}
+          </DialogTitle>
+          <DialogDescription>
+            Parcourez les cartes disponibles, effectuez une sélection manuelle
+            ou laissez le système choisir aléatoirement. Confirmez pour
+            verrouiller la carte secrète.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-1 flex-col gap-5 overflow-hidden">
+          <div className="flex items-center justify-between gap-3 px-6 pt-6">
+            <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+              <span>
+                {selectedCard
+                  ? `${selectedCard.label} est prête à être confirmée.`
+                  : "Aucune carte sélectionnée pour le moment."}
+              </span>
+              <span>
+                Choisissez une carte ou utilisez la sélection aléatoire pour
+                gagner du temps.
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleRandomSelection}
+              disabled={cards.length === 0}
+            >
+              <ShuffleIcon aria-hidden className="mr-2 size-4" />
+              Sélection aléatoire
+            </Button>
+          </div>
+          <ScrollArea className="px-6">
+            <div className="pb-6">
+              <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {cards.map((card) => (
+                  <li key={card.id} className="list-none">
+                    <SelectableCard
+                      card={card}
+                      isSelected={selectedCardId === card.id}
+                      onSelect={() => handleSelectCard(card.id)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </ScrollArea>
+        </div>
+        <DialogFooter className="flex flex-col gap-3 border-t px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            {localError ? (
+              <p className="text-sm text-destructive">{localError}</p>
+            ) : (
+              <Badge variant="outline" className="text-xs uppercase">
+                {selectedCard ? "Prêt à confirmer" : "Sélection requise"}
+              </Badge>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DialogClose asChild>
+              <Button type="button" variant="outline">
+                Annuler
+              </Button>
+            </DialogClose>
+            <Button type="button" onClick={handleConfirm}>
+              Confirmer la carte secrète
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { TargetSelectionModal };

--- a/src/components/room/TurnBar.tsx
+++ b/src/components/room/TurnBar.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  FastForwardIcon,
+  PauseIcon,
+  RotateCcwIcon,
+  TimerIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { GameStatus } from "@/lib/game/types";
+import { cn } from "@/lib/utils";
+
+type HostControlConfig = {
+  readonly onNextTurn?: () => void;
+  readonly nextTurnDisabled: boolean;
+  readonly onPause?: () => void;
+  readonly pauseDisabled: boolean;
+  readonly onResetRound?: () => void;
+  readonly resetDisabled: boolean;
+};
+
+type TurnBarProps = {
+  readonly turn: number | null;
+  readonly activePlayerName: string | null;
+  readonly status: GameStatus;
+  readonly isHost: boolean;
+  readonly canEndTurn: boolean;
+  readonly onEndTurn?: () => void;
+  readonly hostControls: HostControlConfig;
+  readonly className?: string;
+};
+
+const statusLabels: Record<GameStatus, string> = {
+  idle: "Salle inactive",
+  lobby: "Préparation du match",
+  playing: "Partie en cours",
+  finished: "Match terminé",
+};
+
+function formatTurnSummary(
+  turn: number | null,
+  activePlayerName: string | null,
+  status: GameStatus,
+): string {
+  if (status === "lobby") {
+    return "En attente du début de la partie";
+  }
+  if (status === "idle") {
+    return "Salle en veille";
+  }
+  if (turn === null) {
+    return "Tour en attente";
+  }
+  if (!activePlayerName) {
+    return `Tour ${turn}`;
+  }
+  return `Tour ${turn} — ${activePlayerName}`;
+}
+
+function TurnBar({
+  turn,
+  activePlayerName,
+  status,
+  isHost,
+  canEndTurn,
+  onEndTurn,
+  hostControls,
+  className,
+}: TurnBarProps) {
+  const {
+    onNextTurn,
+    nextTurnDisabled,
+    onPause,
+    pauseDisabled,
+    onResetRound,
+    resetDisabled,
+  } = hostControls;
+
+  const turnSummary = formatTurnSummary(turn, activePlayerName, status);
+  const statusLabel = statusLabels[status];
+
+  return (
+    <div
+      className={cn(
+        "sticky bottom-4 z-20 w-full", // anchor near bottom by default
+        className,
+      )}
+    >
+      <div className="rounded-2xl border border-border/60 bg-background/95 px-4 py-3 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/70">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <span className="inline-flex items-center gap-2 text-sm font-medium text-foreground">
+              <TimerIcon aria-hidden className="size-4 text-primary" />
+              {turnSummary}
+            </span>
+            <span className="text-xs text-muted-foreground">{statusLabel}</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {!isHost && canEndTurn && onEndTurn ? (
+              <Button type="button" onClick={onEndTurn}>
+                Terminer mon tour
+              </Button>
+            ) : null}
+            {isHost ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  onClick={onNextTurn}
+                  disabled={nextTurnDisabled || !onNextTurn}
+                >
+                  <FastForwardIcon aria-hidden className="mr-2 size-4" />
+                  Tour suivant
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onPause}
+                  disabled={pauseDisabled || !onPause}
+                >
+                  <PauseIcon aria-hidden className="mr-2 size-4" />
+                  Pause
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onResetRound}
+                  disabled={resetDisabled || !onResetRound}
+                >
+                  <RotateCcwIcon aria-hidden className="mr-2 size-4" />
+                  Réinitialiser
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { TurnBar };


### PR DESCRIPTION
## Summary
- add dedicated TargetSelectionModal, ParticipantsSheet, and TurnBar components
- refactor room page to use modal-driven secret selection, sheet-based participants list, and sticky turn controls while keeping spectator constraints
- surface host-only spectator promotion/kick actions with basic local state handling and prepare host controls wiring

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d157c77030832aa373c060aec9d27d