### PR TITLE
Rename KeyS references to C ki ?

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose of this document
 
-This file defines **the agents** involved in the **KeyS project** (a "Guess Who?"-style game playable as a PWA, full browser, P2P via PeerJS).  
+This file defines **the agents** involved in the **C ki ? project** (a "Guess Who?"-style game playable as a PWA, full browser, P2P via PeerJS).
 Each agent (human, tool, automation) has a specific role. The goal is to ensure **clarity, maintainability, productivity**, and **robustness** in the development cycle.
 
 ---

--- a/docs/UX_AUDIT.md
+++ b/docs/UX_AUDIT.md
@@ -1,4 +1,4 @@
-# KeyS UX Audit
+# C ki ? UX Audit
 
 _Last updated: 2025-09-22 by UX review agent._
 

--- a/docs/UX_CHANGES.md
+++ b/docs/UX_CHANGES.md
@@ -1,4 +1,4 @@
-# KeyS UX Changes Brief
+# C ki ? UX Changes Brief
 
 _Last updated: 2025-09-22 by product UX agent._
 
@@ -93,7 +93,7 @@ Textual wireframes describe the content and interaction stack. Use them as accep
    - Sticky under 640 px, static otherwise.
 2. **Hero block** (`space-y-5`, max width 720 px)
    - Pill label with `SparklesIcon` → “Configuration de la grille”.
-   - `h1`: “Créez votre plateau KeyS personnalisé”.
+   - `h1`: “Créez votre plateau personnalisé pour « C ki ? »”.
    - Paragraph emphasising privacy and instant sharing.
    - Feature bullets row (grid dimensions, image sourcing, autosave cue). Collapses to stacked list on mobile.
 3. **Identity form card**
@@ -113,7 +113,7 @@ Textual wireframes describe the content and interaction stack. Use them as accep
 ### 3.2 Game Screen (`/room/[roomId]`)
 
 1. **Header bar**
-   - Left: room name (fallback “Salle KeyS”) with badge for connection status (`connecté`, `reconnexion`, `erreur`).
+   - Left: room name (fallback “Salle « C ki ? »”) with badge for connection status (`connecté`, `reconnexion`, `erreur`).
    - Center (desktop only): turn timer chip with `TimerIcon` when timer active.
    - Right: icon buttons (Invite, Participants, Règles) + dropdown for settings.
    - On mobile, collapse into overflow menu except for Invite.

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -114,7 +114,7 @@ export default function CreatePage() {
               Configuration de la grille
             </div>
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-              Créez votre plateau KeyS personnalisé
+              Créez votre plateau personnalisé pour « C ki ? »
             </h1>
             <p className="text-base text-muted-foreground sm:text-lg">
               Personnalisez vos cartes depuis l’aperçu interactif puis partagez

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,9 +43,9 @@ if (typeof window !== 'undefined') {
 `;
 
 export const metadata: Metadata = {
-  title: "KeyS Companion",
+  title: "C ki ? Companion",
   description:
-    "Interface de commande pour créer, rejoindre et orchestrer vos parties KeyS en toute simplicité.",
+    "Interface de commande pour créer, rejoindre et orchestrer vos parties « C ki ? » en toute simplicité.",
 };
 
 export default function RootLayout({
@@ -86,8 +86,8 @@ export default function RootLayout({
               <footer className="border-t border-border/70 bg-background/95">
                 <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between md:px-6">
                   <p>
-                    © {new Date().getFullYear()} KeyS. Jeu de déduction sécurisé
-                    et accessible.
+                    © {new Date().getFullYear()} C ki ? – Jeu de déduction
+                    sécurisé et accessible.
                   </p>
                   <div className="flex flex-wrap items-center gap-4">
                     <a

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,10 +48,10 @@ export default function Home() {
         <div className="space-y-6">
           <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
             <SparklesIcon aria-hidden="true" className="size-4" />
-            Votre salle de commande KeyS
+            Votre salle de commande « C ki ? »
           </div>
           <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-            Orchestrez vos parties KeyS, du mobile au bureau
+            Orchestrez vos parties « C ki ? », du mobile au bureau
           </h1>
           <p className="text-base text-muted-foreground sm:text-lg">
             Centralisez la création des salles, pilotez les joueurs et gardez un

--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -1196,7 +1196,7 @@ export default function RoomPage() {
             <div className="space-y-2">
               <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
                 <UsersIcon aria-hidden className="size-4" />
-                Salle KeyS
+                Salle « C ki ? »
               </div>
               <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
                 Salle {roomId}

--- a/src/components/app/Header.tsx
+++ b/src/components/app/Header.tsx
@@ -48,15 +48,15 @@ function Header() {
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-3 md:px-6">
         <Link
           href="/"
-          aria-label="Retour à l’accueil KeyS Companion"
+          aria-label="Retour à l’accueil C ki ? Companion"
           className="group flex items-center gap-2 rounded-md px-2 py-1 font-semibold text-base transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           <span className="relative flex items-center justify-center rounded-md bg-primary/10 p-1 transition-transform group-hover:scale-105">
             <SparklesIcon aria-hidden="true" className="size-5 text-primary" />
           </span>
-          <span className="hidden sm:inline">KeyS Companion</span>
+          <span className="hidden sm:inline">C ki ? Companion</span>
           <span className="text-sm font-medium text-muted-foreground sm:hidden">
-            KeyS
+            C ki ?
           </span>
         </Link>
         <div className="flex flex-1 items-center justify-end gap-1.5">

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -1,5 +1,5 @@
 /**
- * Core domain types for the Guess Who-style KeyS game.
+ * Core domain types for the Guess Who-style « C ki ? » game.
  *
  * The goal is to keep the data contracts explicit, serialisable and easy to validate.
  * Each exported type is paired with a runtime schema in {@link schema.ts}.


### PR DESCRIPTION
## Summary
- replace user-facing branding strings from KeyS to « C ki ? » across layout, hero, and room surfaces
- align supporting documentation and game domain comments with the new name

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16914b134832aab27fa084a41e46e