### PR TITLE
Prevent dropping remote actions before the replicator is ready

### DIFF
--- a/src/lib/p2p/remote-action-queue.test.ts
+++ b/src/lib/p2p/remote-action-queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+
+import { PeerRole } from "./peer";
+import type { GameActionMessagePayload } from "./protocol";
+import { RemoteActionQueue } from "./remote-action-queue";
+
+const createPayload = (suffix: string): GameActionMessagePayload => ({
+  actionId: `action-${suffix}`,
+  action: { type: "game/reset" },
+  issuerPeerId: `peer-${suffix}`,
+  issuerRole: PeerRole.Host,
+  acknowledgedByHost: true,
+});
+
+describe("RemoteActionQueue", () => {
+  it("drains queued payloads in first-in first-out order", () => {
+    const queue = new RemoteActionQueue();
+    const first = createPayload("1");
+    const second = createPayload("2");
+    const third = createPayload("3");
+
+    queue.enqueue(first);
+    queue.enqueue(second);
+    queue.enqueue(third);
+
+    const processed: GameActionMessagePayload[] = [];
+    queue.drain(
+      (payload) => {
+        processed.push(payload);
+      },
+      () => {
+        throw new Error("Unexpected error during drain");
+      },
+    );
+
+    expect(processed).toEqual([first, second, third]);
+    expect(queue.size).toBe(0);
+  });
+
+  it("invokes the error handler when processing fails and continues draining", () => {
+    const queue = new RemoteActionQueue();
+    const first = createPayload("1");
+    const second = createPayload("2");
+
+    queue.enqueue(first);
+    queue.enqueue(second);
+
+    const processedIds: string[] = [];
+    const handledErrors: unknown[] = [];
+
+    queue.drain(
+      (payload) => {
+        processedIds.push(payload.actionId);
+        if (payload === first) {
+          throw new Error("processing failure");
+        }
+      },
+      (error, payload) => {
+        handledErrors.push({ error, payload });
+      },
+    );
+
+    expect(processedIds).toEqual([first.actionId, second.actionId]);
+    expect(handledErrors).toHaveLength(1);
+    expect(
+      (handledErrors[0] as { payload: GameActionMessagePayload }).payload,
+    ).toBe(first);
+    expect(queue.size).toBe(0);
+  });
+});

--- a/src/lib/p2p/remote-action-queue.ts
+++ b/src/lib/p2p/remote-action-queue.ts
@@ -1,0 +1,51 @@
+import type { GameActionMessagePayload } from "./protocol";
+
+/**
+ * Stores remote game action payloads until a replicator becomes available.
+ *
+ * WebRTC connections can deliver actions before the local peer finished
+ * initialising its replicator. This buffer guarantees that those actions are
+ * replayed in a deterministic order once the replicator is ready, preventing
+ * state divergence between peers.
+ */
+export class RemoteActionQueue {
+  private readonly pending: GameActionMessagePayload[] = [];
+
+  /**
+   * Adds a payload to the queue for later processing.
+   */
+  enqueue(payload: GameActionMessagePayload): void {
+    this.pending.push(payload);
+  }
+
+  /**
+   * Processes all queued payloads in FIFO order.
+   *
+   * The provided {@link process} callback is invoked for each payload. If the
+   * callback throws, the error handler receives the error while the queue keeps
+   * draining the remaining payloads.
+   */
+  drain(
+    process: (payload: GameActionMessagePayload) => void,
+    onError: (error: unknown, payload: GameActionMessagePayload) => void,
+  ): void {
+    while (this.pending.length > 0) {
+      const payload = this.pending.shift();
+      if (!payload) {
+        continue;
+      }
+      try {
+        process(payload);
+      } catch (error) {
+        onError(error, payload);
+      }
+    }
+  }
+
+  /**
+   * Returns the number of queued payloads.
+   */
+  get size(): number {
+    return this.pending.length;
+  }
+}


### PR DESCRIPTION
## Summary
- buffer remote game action messages until the action replicator is available on the client
- reuse the existing error handling logic when draining queued messages after the replicator initialises
- cover the remote action queue with unit tests to guarantee FIFO ordering and error propagation

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1695ccbd4832a9d8380e535749cfb