### PR TITLE
Refactor room layout for full-screen dual boards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,3 +124,60 @@
 .page-shell:has(> .full-height-page) {
   padding-bottom: 0;
 }
+
+html.room-screen-html,
+body.room-screen-active {
+  height: 100dvh;
+}
+
+body.room-screen-active {
+  overflow: hidden;
+  overscroll-behavior: none;
+  background-color: var(--background);
+}
+
+.room-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+  overflow: hidden;
+  background-color: var(--background);
+  padding: 16px;
+  padding-top: calc(env(safe-area-inset-top) + 16px);
+  padding-right: calc(env(safe-area-inset-right) + 16px);
+  padding-bottom: calc(env(safe-area-inset-bottom) + 16px);
+  padding-left: calc(env(safe-area-inset-left) + 16px);
+}
+
+@media (min-width: 768px) {
+  .room-screen {
+    gap: 1.5rem;
+  }
+}
+
+body.room-screen-active main {
+  max-width: none;
+  width: 100%;
+  padding: 0;
+  display: flex;
+  flex: 1 1 auto;
+}
+
+body.room-screen-active .page-shell {
+  padding: 0;
+  flex: 1 1 auto;
+  display: flex;
+}
+
+body.room-screen-active .page-shell > .room-screen {
+  flex: 1 1 auto;
+}
+
+body.room-screen-active header,
+body.room-screen-active footer,
+body.room-screen-active [data-mobile-nav="true"] {
+  display: none;
+}

--- a/src/components/app/MobileNav.tsx
+++ b/src/components/app/MobileNav.tsx
@@ -19,7 +19,10 @@ function MobileNav() {
   const [homeItem, createItem, joinItem] = navigationItems;
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 md:hidden">
+    <div
+      data-mobile-nav="true"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 md:hidden"
+    >
       <nav className="pointer-events-auto mx-auto w-full max-w-6xl border-t border-border/70 bg-background/95 px-1 pb-[calc(env(safe-area-inset-bottom)_+_0.75rem)] pt-2 shadow-[0_-8px_24px_-12px_rgba(15,23,42,0.35)] backdrop-blur">
         <div className="grid grid-cols-5 items-end gap-1">
           {[homeItem, createItem].map((item) => {

--- a/src/components/room/BoardsArea.tsx
+++ b/src/components/room/BoardsArea.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+export type BoardsLayout = "horizontal" | "vertical";
+
+type BoardsAreaBoard = {
+  readonly key: string;
+  readonly content: ReactNode;
+};
+
+type BoardsAreaProps = {
+  readonly boards: readonly BoardsAreaBoard[];
+  readonly onLayoutChange?: (layout: BoardsLayout) => void;
+  readonly className?: string;
+};
+
+const GAP_HORIZONTAL = 24;
+const GAP_VERTICAL = 20;
+
+function clampScale(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  if (value <= 0) {
+    return 0.0001;
+  }
+  return Math.min(value, 1);
+}
+
+function createEmptySizes(count: number): Size[] {
+  return Array.from({ length: count }, () => ({ width: 0, height: 0 }));
+}
+
+export function BoardsArea({
+  boards,
+  onLayoutChange,
+  className,
+}: BoardsAreaProps) {
+  const areaRef = useRef<HTMLDivElement | null>(null);
+  const boardRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const previousLayoutRef = useRef<BoardsLayout>("horizontal");
+
+  const [areaSize, setAreaSize] = useState<Size>({ width: 0, height: 0 });
+  const [boardSizes, setBoardSizes] = useState<Size[]>(() =>
+    createEmptySizes(boards.length),
+  );
+
+  const measureBoards = useCallback(() => {
+    if (boardRefs.current.length === 0) {
+      return createEmptySizes(boards.length);
+    }
+    return boardRefs.current.map((node) => {
+      if (!node) {
+        return { width: 0, height: 0 } satisfies Size;
+      }
+      return {
+        width: node.offsetWidth,
+        height: node.offsetHeight,
+      } satisfies Size;
+    });
+  }, [boards.length]);
+
+  const handleBoardRef = useCallback(
+    (index: number, node: HTMLDivElement | null) => {
+      boardRefs.current[index] = node;
+      setBoardSizes(measureBoards());
+    },
+    [measureBoards],
+  );
+
+  useEffect(() => {
+    boardRefs.current = boardRefs.current.slice(0, boards.length);
+    setBoardSizes((sizes) => {
+      if (sizes.length === boards.length) {
+        return sizes;
+      }
+      return measureBoards();
+    });
+  }, [boards.length, measureBoards]);
+
+  useEffect(() => {
+    const node = areaRef.current;
+    if (!node) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setAreaSize((previous) => {
+          if (previous.width === width && previous.height === height) {
+            return previous;
+          }
+          return { width, height } satisfies Size;
+        });
+      }
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (boardRefs.current.length === 0) {
+      setBoardSizes(createEmptySizes(boards.length));
+      return;
+    }
+
+    const observers = boardRefs.current.map((node) => {
+      if (!node) {
+        return null;
+      }
+      const observer = new ResizeObserver(() => {
+        setBoardSizes(measureBoards());
+      });
+      observer.observe(node);
+      return observer;
+    });
+
+    setBoardSizes(measureBoards());
+
+    return () => {
+      for (const observer of observers) {
+        observer?.disconnect();
+      }
+    };
+  }, [boards.length, measureBoards]);
+
+  const layout = useMemo(() => {
+    const boardCount = boards.length;
+    if (
+      boardCount === 0 ||
+      areaSize.width <= 0 ||
+      areaSize.height <= 0 ||
+      boardSizes.length === 0
+    ) {
+      return {
+        orientation: "horizontal" as BoardsLayout,
+        scale: 1,
+        gap: GAP_HORIZONTAL,
+      };
+    }
+
+    const maxWidth = Math.max(...boardSizes.map((size) => size.width));
+    const maxHeight = Math.max(...boardSizes.map((size) => size.height));
+
+    if (maxWidth === 0 || maxHeight === 0) {
+      return {
+        orientation: "horizontal" as BoardsLayout,
+        scale: 1,
+        gap: GAP_HORIZONTAL,
+      };
+    }
+
+    const compute = (orientation: BoardsLayout) => {
+      const gap = orientation === "horizontal" ? GAP_HORIZONTAL : GAP_VERTICAL;
+      if (orientation === "horizontal") {
+        const availableWidth = Math.max(
+          areaSize.width - (boardCount - 1) * gap,
+          0,
+        );
+        const widthScale = availableWidth / Math.max(maxWidth * boardCount, 1);
+        const heightScale = areaSize.height / Math.max(maxHeight, 1);
+        const scale = clampScale(Math.min(widthScale, heightScale));
+        return { scale, gap };
+      }
+      const availableHeight = Math.max(
+        areaSize.height - (boardCount - 1) * gap,
+        0,
+      );
+      const heightScale = availableHeight / Math.max(maxHeight * boardCount, 1);
+      const widthScale = areaSize.width / Math.max(maxWidth, 1);
+      const scale = clampScale(Math.min(heightScale, widthScale));
+      return { scale, gap };
+    };
+
+    const horizontal = compute("horizontal");
+    const vertical = compute("vertical");
+
+    if (horizontal.scale >= vertical.scale) {
+      return {
+        orientation: "horizontal" as BoardsLayout,
+        scale: horizontal.scale,
+        gap: horizontal.gap,
+      };
+    }
+
+    return {
+      orientation: "vertical" as BoardsLayout,
+      scale: vertical.scale,
+      gap: vertical.gap,
+    };
+  }, [areaSize.height, areaSize.width, boardSizes, boards.length]);
+
+  useEffect(() => {
+    if (!onLayoutChange) {
+      return;
+    }
+    if (previousLayoutRef.current === layout.orientation) {
+      return;
+    }
+    previousLayoutRef.current = layout.orientation;
+    onLayoutChange(layout.orientation);
+  }, [layout.orientation, onLayoutChange]);
+
+  const isReady = useMemo(
+    () =>
+      areaSize.width > 0 &&
+      areaSize.height > 0 &&
+      boardSizes.length === boards.length &&
+      boardSizes.every((size) => size.width > 0 && size.height > 0),
+    [areaSize.height, areaSize.width, boardSizes, boards.length],
+  );
+
+  return (
+    <div
+      ref={areaRef}
+      aria-busy={!isReady}
+      data-orientation={layout.orientation}
+      className={cn(
+        "boards-area relative flex size-full items-center justify-center overflow-hidden",
+        layout.orientation === "horizontal" ? "flex-row" : "flex-col",
+        className,
+      )}
+      style={{ gap: `${layout.gap}px` }}
+    >
+      {boards.map((board, index) => {
+        const size = boardSizes[index] ?? { width: 0, height: 0 };
+        const scaledWidth = size.width * layout.scale;
+        const scaledHeight = size.height * layout.scale;
+        const slotStyle: CSSProperties = {
+          width: scaledWidth,
+          height: scaledHeight,
+        };
+        const isBoardReady = size.width > 0 && size.height > 0;
+
+        return (
+          <div
+            key={board.key}
+            className={cn(
+              "boards-area__slot flex flex-shrink-0 items-start justify-center transition-opacity duration-200",
+              isReady && isBoardReady ? "opacity-100" : "opacity-0",
+            )}
+            style={slotStyle}
+          >
+            <div
+              className="boards-area__scale"
+              style={{
+                transform: `scale(${layout.scale})`,
+                transformOrigin: "top left",
+                contain: "layout paint size",
+                willChange: "transform",
+              }}
+            >
+              <div
+                ref={(node) => handleBoardRef(index, node)}
+                className="boards-area__content inline-flex"
+              >
+                {board.content}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/room/InviteDialog.tsx
+++ b/src/components/room/InviteDialog.tsx
@@ -53,6 +53,7 @@ interface InviteDialogProps {
   canJoinAsPlayer: boolean;
   onJoin: (nickname: string) => void;
   isJoining: boolean;
+  triggerClassName?: string;
 }
 
 type JoinRole = "player" | "spectator";
@@ -74,6 +75,7 @@ export function InviteDialog({
   canJoinAsPlayer,
   onJoin,
   isJoining,
+  triggerClassName,
 }: InviteDialogProps) {
   const [origin, setOrigin] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
@@ -242,7 +244,7 @@ export function InviteDialog({
           type="button"
           variant="outline"
           size="sm"
-          className="flex items-center gap-2"
+          className={cn("flex items-center gap-2", triggerClassName)}
         >
           <CopyIcon aria-hidden className="size-4" />
           Inviter

--- a/src/components/room/ParticipantsSheet.tsx
+++ b/src/components/room/ParticipantsSheet.tsx
@@ -47,6 +47,7 @@ type ParticipantsSheetProps = {
   readonly onPromoteSpectator?: (spectatorId: string) => void;
   readonly onKickSpectator?: (spectatorId: string) => void;
   readonly onKickPlayer?: (playerId: string) => void;
+  readonly triggerClassName?: string;
 };
 
 const roleLabels: Record<PlayerRole, string> = {
@@ -214,6 +215,7 @@ function ParticipantsSheet({
   onPromoteSpectator,
   onKickSpectator,
   onKickPlayer,
+  triggerClassName,
 }: ParticipantsSheetProps) {
   const playerCount = players.length;
   const hostPlayer = useMemo(
@@ -232,7 +234,7 @@ function ParticipantsSheet({
           type="button"
           variant="outline"
           size="sm"
-          className="flex items-center gap-2"
+          className={cn("flex items-center gap-2", triggerClassName)}
         >
           <UsersIcon aria-hidden className="size-4" />
           Participants ({playerCount}/2)

--- a/src/components/room/PlayerBoard.tsx
+++ b/src/components/room/PlayerBoard.tsx
@@ -185,7 +185,7 @@ export function PlayerBoard({
           </div>
           <div className="min-h-0 flex-1 overflow-hidden">
             <ul
-              className="grid h-full list-none gap-2 overflow-auto pr-1 sm:gap-3"
+              className="grid h-full list-none gap-2 overflow-hidden pr-1 sm:gap-3"
               style={{ gridTemplateColumns: templateColumns }}
               aria-label={`Plateau de ${player.name}`}
             >

--- a/src/components/room/RoomInformationDialog.tsx
+++ b/src/components/room/RoomInformationDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import type { GameStatus, Grid } from "@/lib/game/types";
+import { cn } from "@/lib/utils";
 
 import { formatStatusLabel } from "./roomLabels";
 
@@ -20,6 +21,7 @@ interface RoomInformationDialogProps {
   grid: Grid;
   status: GameStatus;
   hostName: string | null;
+  triggerClassName?: string;
 }
 
 export function RoomInformationDialog({
@@ -27,6 +29,7 @@ export function RoomInformationDialog({
   grid,
   status,
   hostName,
+  triggerClassName,
 }: RoomInformationDialogProps) {
   return (
     <Dialog>
@@ -35,7 +38,7 @@ export function RoomInformationDialog({
           type="button"
           variant="outline"
           size="sm"
-          className="flex items-center gap-2"
+          className={cn("flex items-center gap-2", triggerClassName)}
         >
           <InfoIcon aria-hidden className="size-4" />
           Infos salle


### PR DESCRIPTION
## Summary
- introduce a full-screen `room-screen` shell with safe-area padding, no page scroll, and dedicated utility panel scroll
- add a `BoardsArea` component that observes available space and scales both player boards while switching between horizontal and vertical layouts
- restructure the room page to keep both boards visible, provide quick-access actions, and support custom trigger styling for dialogs and sheets used in the utility panel
- add data hooks for hiding the mobile nav in game mode and prevent per-board overflow to keep grids entirely visible

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16f0ade10832ab8e6cad28daa10a4