### PR TITLE
Prompt guess confirmation when only one card remains visible

### DIFF
--- a/docs/UX_CHANGES.md
+++ b/docs/UX_CHANGES.md
@@ -133,7 +133,14 @@ Textual wireframes describe the content and interaction stack. Use them as accep
    - Step list: choose opponent tile → confirm → broadcast message.
    - Grid preview 3 columns, uses same tile component as board but in compact mode.
    - Footer: destructive button “Annuler”, primary button “Valider la cible”.
-5. **Turn bar** (anchored bottom, full-width)
+5. **Guess confirmation modal** (auto-triggered when only one card stays visible)
+   - Title: “Voulez-vous valider ce personnage ?”. Description reminds players that only one card is visible and names the remaining opponent.
+   - Body: recap block with the candidate card label and description so the player can double-check before committing.
+   - Footer actions:
+     - **“Oui, annoncer”** sends the guess (`turn/guess`) to the opponent immediately.
+     - **“Non, continuer”** flips back the previously hidden card so the player returns to multi-card state.
+   - Closing via escape/outside tap behaves like “Non, continuer” to avoid accidental lock-in.
+6. **Turn bar** (anchored bottom, full-width)
    - Left: textual status (“À vous de jouer”, “Patientez…”, “Victoire !”).
    - Center: action buttons contextual to role (e.g., “Brasser le paquet”, “Marquer comme trouvé”).
    - Right: network feedback dot + tooltip for latency.

--- a/src/app/room/[roomId]/guessConfirmation.test.ts
+++ b/src/app/room/[roomId]/guessConfirmation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Grid, Player } from "@/lib/game/types";
+import { PlayerRole } from "@/lib/game/types";
+
+import { analyseGuessConfirmationContext } from "./guessConfirmation";
+
+const createGrid = (): Grid => ({
+  id: "grid-test",
+  name: "Test",
+  rows: 2,
+  columns: 2,
+  cards: [
+    { id: "card-a", label: "Alpha" },
+    { id: "card-b", label: "Beta" },
+    { id: "card-c", label: "Gamma" },
+    { id: "card-d", label: "Delta" },
+  ],
+});
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  id: "player-local",
+  name: "Local",
+  role: PlayerRole.Host,
+  flippedCardIds: [],
+  ...overrides,
+});
+
+describe("analyseGuessConfirmationContext", () => {
+  it("returns null when grid or player is missing", () => {
+    expect(analyseGuessConfirmationContext(null, null, "card-a")).toBeNull();
+
+    const grid = createGrid();
+    expect(analyseGuessConfirmationContext(grid, null, "card-a")).toBeNull();
+
+    const player = createPlayer();
+    expect(analyseGuessConfirmationContext(null, player, "card-a")).toBeNull();
+  });
+
+  it("tracks the only remaining visible card when a new card is masked", () => {
+    const grid = createGrid();
+    const player = createPlayer({ flippedCardIds: ["card-b", "card-c"] });
+
+    const result = analyseGuessConfirmationContext(grid, player, "card-d");
+    expect(result).not.toBeNull();
+    expect(result?.cardWasHiddenBeforeToggle).toBe(false);
+    expect(result?.visibleCardIdsAfter).toEqual(["card-a"]);
+    expect(result?.remainingVisibleCardId).toBe("card-a");
+  });
+
+  it("does not flag a guess when multiple cards stay visible", () => {
+    const grid = createGrid();
+    const player = createPlayer({ flippedCardIds: ["card-b"] });
+
+    const result = analyseGuessConfirmationContext(grid, player, "card-c");
+    expect(result).not.toBeNull();
+    expect(result?.cardWasHiddenBeforeToggle).toBe(false);
+    expect(result?.visibleCardIdsAfter.sort()).toEqual(
+      ["card-a", "card-d"].sort(),
+    );
+    expect(result?.remainingVisibleCardId).toBeNull();
+  });
+
+  it("removes the toggled card from the hidden list when revealing it", () => {
+    const grid = createGrid();
+    const player = createPlayer({ flippedCardIds: ["card-b", "card-c"] });
+
+    const result = analyseGuessConfirmationContext(grid, player, "card-b");
+    expect(result).not.toBeNull();
+    expect(result?.cardWasHiddenBeforeToggle).toBe(true);
+    expect(result?.hiddenCardIdsAfter.sort()).toEqual(["card-c"].sort());
+    expect(result?.remainingVisibleCardId).toBeNull();
+  });
+});

--- a/src/app/room/[roomId]/guessConfirmation.ts
+++ b/src/app/room/[roomId]/guessConfirmation.ts
@@ -1,0 +1,41 @@
+import type { Grid, Player } from "@/lib/game/types";
+
+export interface GuessConfirmationAnalysis {
+  readonly cardWasHiddenBeforeToggle: boolean;
+  readonly hiddenCardIdsAfter: readonly string[];
+  readonly visibleCardIdsAfter: readonly string[];
+  readonly remainingVisibleCardId: string | null;
+}
+
+export function analyseGuessConfirmationContext(
+  grid: Grid | null,
+  player: Player | null,
+  cardId: string,
+): GuessConfirmationAnalysis | null {
+  if (!grid || !player) {
+    return null;
+  }
+
+  const hiddenCardIds = new Set(player.flippedCardIds);
+  const cardWasHiddenBeforeToggle = hiddenCardIds.has(cardId);
+
+  if (cardWasHiddenBeforeToggle) {
+    hiddenCardIds.delete(cardId);
+  } else {
+    hiddenCardIds.add(cardId);
+  }
+
+  const hiddenCardIdsAfter = Array.from(hiddenCardIds);
+  const visibleCardIdsAfter = grid.cards
+    .map((card) => card.id)
+    .filter((id) => !hiddenCardIds.has(id));
+  const remainingVisibleCardId =
+    visibleCardIdsAfter.length === 1 ? (visibleCardIdsAfter[0] ?? null) : null;
+
+  return {
+    cardWasHiddenBeforeToggle,
+    hiddenCardIdsAfter,
+    visibleCardIdsAfter,
+    remainingVisibleCardId,
+  } satisfies GuessConfirmationAnalysis;
+}


### PR DESCRIPTION
## Summary
- add a helper to analyse card toggle outcomes and detect the last visible card
- extend the room page to open a confirmation dialog, trigger guesses, and restore cards on cancel
- document the new confirmation flow in the UX brief

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d194521148832ab7e89bf4fcc73220