### PR TITLE
Handle incorrect guesses during play

### DIFF
--- a/src/components/room/TurnBar.tsx
+++ b/src/components/room/TurnBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AlertCircleIcon,
   FastForwardIcon,
   PauseIcon,
   RotateCcwIcon,
@@ -20,6 +21,12 @@ type HostControlConfig = {
   readonly resetDisabled: boolean;
 };
 
+type GuessFailureSummary = {
+  readonly guesserName: string;
+  readonly targetName: string;
+  readonly cardLabel: string;
+};
+
 type TurnBarProps = {
   readonly turn: number | null;
   readonly activePlayerName: string | null;
@@ -28,6 +35,7 @@ type TurnBarProps = {
   readonly canEndTurn: boolean;
   readonly onEndTurn?: () => void;
   readonly hostControls: HostControlConfig;
+  readonly lastGuessFailure?: GuessFailureSummary | null;
   readonly className?: string;
 };
 
@@ -66,6 +74,7 @@ function TurnBar({
   canEndTurn,
   onEndTurn,
   hostControls,
+  lastGuessFailure = null,
   className,
 }: TurnBarProps) {
   const {
@@ -79,6 +88,9 @@ function TurnBar({
 
   const turnSummary = formatTurnSummary(turn, activePlayerName, status);
   const statusLabel = statusLabels[status];
+  const failureDescription = lastGuessFailure
+    ? `${lastGuessFailure.guesserName} a annoncé ${lastGuessFailure.cardLabel}, mais ${lastGuessFailure.targetName} protégeait une autre carte.`
+    : null;
 
   return (
     <div
@@ -134,6 +146,20 @@ function TurnBar({
             ) : null}
           </div>
         </div>
+        {failureDescription ? (
+          <div className="mt-3 flex items-start gap-3 rounded-xl border border-destructive/50 bg-destructive/10 px-3 py-2">
+            <AlertCircleIcon
+              aria-hidden
+              className="mt-0.5 size-4 text-destructive"
+            />
+            <div className="space-y-0.5 text-destructive">
+              <p className="text-sm font-semibold">Proposition incorrecte</p>
+              <p className="text-xs leading-relaxed text-destructive/90">
+                {failureDescription}
+              </p>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/lib/game/schema.ts
+++ b/src/lib/game/schema.ts
@@ -132,6 +132,7 @@ const playingStateSchemaInternal: z.ZodType<PlayingState> = z
     players: z.array(playerSchema).length(2),
     activePlayerId: z.string().min(1),
     turn: z.number().int().positive(),
+    lastGuessResult: guessResultSchema.nullable(),
   })
   .strict()
   .superRefine((state, ctx) => {

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -106,6 +106,8 @@ export interface PlayingState {
   activePlayerId: string;
   /** Sequential turn counter starting at 1. */
   turn: number;
+  /** Result of the most recent guess attempt while the match is active. */
+  lastGuessResult: GuessResult | null;
 }
 
 export interface FinishedState {


### PR DESCRIPTION
## Summary
- keep matches active after an incorrect guess by resetting the guesser board, advancing the turn and storing the latest guess result
- extend the playing state schema and test suite to validate the new guess tracking behaviour
- surface failed guesses in the UI through TurnBar messaging and toast notifications

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d19831d4ac832ab06b7ee87544fa31