### PR TITLE
Fix ParticipantsSheet description markup to avoid nested paragraphs

### DIFF
--- a/src/components/room/ParticipantsSheet.tsx
+++ b/src/components/room/ParticipantsSheet.tsx
@@ -249,11 +249,15 @@ function ParticipantsSheet({
             <ShieldIcon aria-hidden className="size-5 text-primary" />
             Participants et rôles
           </SheetTitle>
-          <SheetDescription className="space-y-1 text-sm">
-            <p>Suivez les connexions et gérez les accès à la partie.</p>
-            <p className="text-xs text-muted-foreground">
-              {statusLabel} — {turnLabel}
-            </p>
+          <SheetDescription asChild className="space-y-1">
+            <div>
+              <p className="m-0">
+                Suivez les connexions et gérez les accès à la partie.
+              </p>
+              <p className="m-0 text-xs text-muted-foreground">
+                {statusLabel} — {turnLabel}
+              </p>
+            </div>
           </SheetDescription>
         </SheetHeader>
         <ScrollArea className="flex-1 px-6 py-4">


### PR DESCRIPTION
## Summary
- render the participants sheet description via `asChild` to remove invalid nested paragraph markup
- keep the two description lines with zero default margins to preserve spacing and typography

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a86c08e8832aabfcab7fb1c53f76