### PR TITLE
Allow host to update nickname during role selection

### DIFF
--- a/src/lib/game/schema.ts
+++ b/src/lib/game/schema.ts
@@ -233,6 +233,19 @@ export const setSecretActionSchema = z
   })
   .strict();
 
+export const updatePlayerNameActionSchema = z
+  .object({
+    type: z.literal<"game/updatePlayerName">("game/updatePlayerName"),
+    payload: z.object({
+      playerId: z.string().min(1),
+      name: z
+        .string()
+        .min(1, "Player name is required")
+        .max(40, "Player name cannot exceed 40 characters"),
+    }),
+  })
+  .strict();
+
 export const startGameActionSchema = z
   .object({
     type: z.literal<"game/start">("game/start"),
@@ -279,6 +292,7 @@ export const resetActionSchema = z
   .strict();
 
 export const synchronisedActionSchema = z.discriminatedUnion("type", [
+  updatePlayerNameActionSchema,
   flipCardActionSchema,
   endTurnActionSchema,
   guessActionSchema,
@@ -289,6 +303,7 @@ export const actionSchema: z.ZodType<Action> = z.discriminatedUnion("type", [
   createLobbyActionSchema,
   joinLobbyActionSchema,
   setSecretActionSchema,
+  updatePlayerNameActionSchema,
   startGameActionSchema,
   flipCardActionSchema,
   endTurnActionSchema,

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -142,6 +142,14 @@ export type JoinLobbyAction = {
   };
 };
 
+export type UpdatePlayerNameAction = {
+  type: "game/updatePlayerName";
+  payload: {
+    playerId: string;
+    name: string;
+  };
+};
+
 export type SetSecretAction = {
   type: "game/setSecret";
   payload: {
@@ -188,6 +196,7 @@ export type ResetAction = {
 export type Action =
   | CreateLobbyAction
   | JoinLobbyAction
+  | UpdatePlayerNameAction
   | SetSecretAction
   | StartGameAction
   | FlipCardAction
@@ -200,6 +209,7 @@ export type Action =
  * initial snapshot has been exchanged.
  */
 export type SynchronisedAction =
+  | Extract<Action, { type: "game/updatePlayerName" }>
   | Extract<Action, { type: "turn/flipCard" }>
   | Extract<Action, { type: "turn/end" }>
   | Extract<Action, { type: "turn/guess" }>

--- a/src/lib/storage/session.ts
+++ b/src/lib/storage/session.ts
@@ -9,6 +9,26 @@ const isBrowser = typeof window !== "undefined";
 const createStorageKey = (roomId: string): string =>
   `${HOST_SESSION_PREFIX}${roomId}`;
 
+const ensureBrowserEnvironment = (): void => {
+  if (!isBrowser) {
+    throw new Error(
+      "Persisting a host session is only supported in the browser",
+    );
+  }
+};
+
+const writeHostPreparationRecord = (record: HostPreparationRecord): void => {
+  ensureBrowserEnvironment();
+
+  try {
+    const key = createStorageKey(record.roomId);
+    window.localStorage.setItem(key, JSON.stringify(record));
+  } catch (error) {
+    console.error("Impossible d'enregistrer la préparation de partie.", error);
+    throw error;
+  }
+};
+
 export interface HostPreparationRecord {
   roomId: string;
   nickname: string;
@@ -21,24 +41,16 @@ export interface HostPreparationRecord {
 export const persistHostPreparation = (
   record: Omit<HostPreparationRecord, "createdAt">,
 ): void => {
-  if (!isBrowser) {
-    throw new Error(
-      "Persisting a host session is only supported in the browser",
-    );
-  }
-
   const payload: HostPreparationRecord = {
     ...record,
     createdAt: Date.now(),
   };
 
-  try {
-    const key = createStorageKey(record.roomId);
-    window.localStorage.setItem(key, JSON.stringify(payload));
-  } catch (error) {
-    console.error("Impossible d'enregistrer la préparation de partie.", error);
-    throw error;
-  }
+  writeHostPreparationRecord(payload);
+};
+
+export const updateHostPreparation = (record: HostPreparationRecord): void => {
+  writeHostPreparationRecord(record);
 };
 
 export const loadHostPreparation = (


### PR DESCRIPTION
## Summary
- enable hosts to edit their nickname directly from the role selection screen and update the underlying session storage
- add a `game/updatePlayerName` action with validation so name changes propagate through state, snapshots, and peer sync
- extend reducer tests to cover nickname updates across lobby and playing phases

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d1a970dbf8832ab92d1976bc67cf7e