### PR TITLE
Implement synchronized spectator roster

### DIFF
--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -89,10 +89,21 @@ import {
 import { PeerRole } from "@/lib/p2p/peer";
 import {
   GAME_PROTOCOL_NAMESPACE,
+  GAME_PROTOCOL_VERSION,
   type GameActionMessagePayload,
+  type SpectatorUpdateMessagePayload,
   validateGameActionMessage,
+  validateSpectatorRosterMessage,
+  validateSpectatorUpdateMessage,
 } from "@/lib/p2p/protocol";
 import { RemoteActionQueue } from "@/lib/p2p/remote-action-queue";
+import {
+  addOrUpdateSpectator,
+  normaliseSpectatorName,
+  normaliseSpectatorRoster,
+  removeSpectatorById,
+  type SpectatorProfile,
+} from "@/lib/room/spectators";
 import { decodeGridFromToken } from "@/lib/share/url";
 import {
   loadPartySession,
@@ -111,11 +122,6 @@ import {
   type RoomPeerCreationConfig,
   useRoomPeerRuntime,
 } from "./hooks/useRoomPeerRuntime";
-
-interface Spectator {
-  id: string;
-  name: string;
-}
 
 type PlayerSummary = {
   player: Player;
@@ -162,7 +168,7 @@ export default function RoomPage() {
     createInitialState(),
   );
   const [actionError, setActionError] = useState<string | null>(null);
-  const [spectators, setSpectators] = useState<readonly Spectator[]>([]);
+  const [spectators, setSpectators] = useState<readonly SpectatorProfile[]>([]);
   const [secretSelectionPlayerId, setSecretSelectionPlayerId] = useState<
     string | null
   >(null);
@@ -248,6 +254,15 @@ export default function RoomPage() {
   const hasLoadedGuestSessionRef = useRef(false);
   const lastPersistedPartyStateRef = useRef<string | null>(null);
   const lastPersistedGuestSessionRef = useRef<string | null>(null);
+  const spectatorPresencePendingRef =
+    useRef<SpectatorUpdateMessagePayload | null>(null);
+  const lastSentSpectatorPresenceRef = useRef<{
+    spectatorId: string;
+    name: string;
+    present: boolean;
+  } | null>(null);
+  const activeSpectatorIdentityRef = useRef<SpectatorProfile | null>(null);
+  const previousViewAsSpectatorRef = useRef(viewAsSpectator);
   if (!pendingRemoteActionsRef.current) {
     pendingRemoteActionsRef.current = new RemoteActionQueue();
   }
@@ -754,21 +769,65 @@ export default function RoomPage() {
     if (!runtime) {
       return;
     }
-    const unsubscribe = runtime.onMessage("game/action", (message) => {
-      try {
-        const payload = validateGameActionMessage(message.payload);
-        processRemotePayload(payload);
-      } catch (error) {
-        handleRemoteProcessingError(error);
-      }
-    });
+    const unsubscribeGameAction = runtime.onMessage(
+      "game/action",
+      (message) => {
+        try {
+          const payload = validateGameActionMessage(message.payload);
+          processRemotePayload(payload);
+        } catch (error) {
+          handleRemoteProcessingError(error);
+        }
+      },
+    );
+    const unsubscribeSpectatorUpdate = runtime.onMessage(
+      "spectator/update",
+      (message) => {
+        if (
+          resolvedPeerRole !== PeerRole.Host ||
+          runtime.protocolVersion !== GAME_PROTOCOL_VERSION
+        ) {
+          return;
+        }
+        try {
+          const payload = validateSpectatorUpdateMessage(message.payload);
+          setSpectators((current) =>
+            payload.present
+              ? addOrUpdateSpectator(current, payload.spectator)
+              : removeSpectatorById(current, payload.spectator.id),
+          );
+        } catch (error) {
+          console.error("Payload spectateur distant invalide.", error);
+        }
+      },
+    );
+    const unsubscribeSpectatorRoster = runtime.onMessage(
+      "spectator/roster",
+      (message) => {
+        if (
+          resolvedPeerRole !== PeerRole.Guest ||
+          runtime.protocolVersion !== GAME_PROTOCOL_VERSION
+        ) {
+          return;
+        }
+        try {
+          const payload = validateSpectatorRosterMessage(message.payload);
+          setSpectators(normaliseSpectatorRoster(payload.spectators));
+        } catch (error) {
+          console.error("Liste de spectateurs invalide.", error);
+        }
+      },
+    );
     return () => {
-      unsubscribe();
+      unsubscribeGameAction();
+      unsubscribeSpectatorUpdate();
+      unsubscribeSpectatorRoster();
     };
   }, [
     peerConnection.runtime,
     processRemotePayload,
     handleRemoteProcessingError,
+    resolvedPeerRole,
   ]);
 
   useEffect(() => {
@@ -885,6 +944,42 @@ export default function RoomPage() {
   const canonicalLocalPlayerName = canonicalLocalPlayer?.name ?? null;
   const canonicalLocalPlayerRole = canonicalLocalPlayer?.role ?? null;
   const isLocalHost = canonicalLocalPlayerRole === PlayerRole.Host;
+  const trimmedRoleSelectionNickname = useMemo(
+    () => roleSelectionNickname.trim(),
+    [roleSelectionNickname],
+  );
+  const localSpectatorId = useMemo(() => {
+    if (canonicalLocalPlayerId) {
+      return canonicalLocalPlayerId;
+    }
+    if (hostPreparation) {
+      return hostPreparation.hostId;
+    }
+    return localGuestId;
+  }, [canonicalLocalPlayerId, hostPreparation, localGuestId]);
+  const localSpectatorProfile = useMemo<SpectatorProfile | null>(() => {
+    if (!localSpectatorId) {
+      return null;
+    }
+    const candidateName =
+      canonicalLocalPlayerName ??
+      localGuestName ??
+      (hostPreparation ? hostPreparation.nickname : null) ??
+      (trimmedRoleSelectionNickname.length > 0
+        ? trimmedRoleSelectionNickname
+        : null) ??
+      "";
+    return {
+      id: localSpectatorId,
+      name: normaliseSpectatorName(candidateName, localSpectatorId),
+    } satisfies SpectatorProfile;
+  }, [
+    localSpectatorId,
+    canonicalLocalPlayerName,
+    localGuestName,
+    hostPreparation,
+    trimmedRoleSelectionNickname,
+  ]);
   useEffect(() => {
     if (!isRoleSelectionOpen) {
       return;
@@ -897,6 +992,188 @@ export default function RoomPage() {
       setRoleSelectionNickname(localGuestName);
     }
   }, [isRoleSelectionOpen, canonicalLocalPlayerName, localGuestName]);
+  useEffect(() => {
+    activeSpectatorIdentityRef.current =
+      viewAsSpectator && localSpectatorProfile ? localSpectatorProfile : null;
+  }, [viewAsSpectator, localSpectatorProfile]);
+  const emitSpectatorPresence = useCallback(
+    (profile: SpectatorProfile, present: boolean) => {
+      if (resolvedPeerRole !== PeerRole.Guest) {
+        return;
+      }
+      const runtime = peerConnection.runtime;
+      const protocolVersion = runtime?.protocolVersion;
+      const payload: SpectatorUpdateMessagePayload = {
+        spectator: profile,
+        present,
+        issuedAt: Date.now(),
+      };
+      const lastSent = lastSentSpectatorPresenceRef.current;
+      if (
+        lastSent &&
+        lastSent.spectatorId === profile.id &&
+        lastSent.present === present &&
+        lastSent.name === profile.name
+      ) {
+        return;
+      }
+      if (!runtime || protocolVersion !== GAME_PROTOCOL_VERSION) {
+        spectatorPresencePendingRef.current = payload;
+      } else {
+        try {
+          runtime.send("spectator/update", payload);
+          spectatorPresencePendingRef.current = null;
+        } catch (error) {
+          console.error(
+            "Impossible d’envoyer la mise à jour de présence spectateur.",
+            error,
+          );
+          spectatorPresencePendingRef.current = payload;
+        }
+      }
+      lastSentSpectatorPresenceRef.current = {
+        spectatorId: profile.id,
+        name: profile.name,
+        present,
+      };
+    },
+    [peerConnection.runtime, resolvedPeerRole],
+  );
+  useEffect(() => {
+    if (resolvedPeerRole !== PeerRole.Guest) {
+      spectatorPresencePendingRef.current = null;
+      lastSentSpectatorPresenceRef.current = null;
+      return;
+    }
+    const runtime = peerConnection.runtime;
+    if (!runtime || runtime.protocolVersion !== GAME_PROTOCOL_VERSION) {
+      return;
+    }
+    const pending = spectatorPresencePendingRef.current;
+    if (!pending) {
+      return;
+    }
+    try {
+      runtime.send("spectator/update", pending);
+      lastSentSpectatorPresenceRef.current = {
+        spectatorId: pending.spectator.id,
+        name: pending.spectator.name,
+        present: pending.present,
+      };
+      spectatorPresencePendingRef.current = null;
+    } catch (error) {
+      console.error(
+        "Impossible d’envoyer la mise à jour de présence spectateur.",
+        error,
+      );
+    }
+  }, [peerConnection.runtime, resolvedPeerRole]);
+  useEffect(() => {
+    const identity = localSpectatorProfile;
+    if (!identity) {
+      return;
+    }
+    const previouslyViewing = previousViewAsSpectatorRef.current;
+    previousViewAsSpectatorRef.current = viewAsSpectator;
+
+    if (viewAsSpectator) {
+      setSpectators((current) => addOrUpdateSpectator(current, identity));
+      if (resolvedPeerRole === PeerRole.Guest) {
+        emitSpectatorPresence(identity, true);
+      }
+      return;
+    }
+
+    if (previouslyViewing) {
+      setSpectators((current) => removeSpectatorById(current, identity.id));
+      if (resolvedPeerRole === PeerRole.Guest) {
+        emitSpectatorPresence(identity, false);
+      }
+      return;
+    }
+
+    if (resolvedPeerRole === PeerRole.Guest) {
+      emitSpectatorPresence(identity, false);
+    }
+  }, [
+    emitSpectatorPresence,
+    localSpectatorProfile,
+    resolvedPeerRole,
+    viewAsSpectator,
+  ]);
+  useEffect(() => {
+    if (resolvedPeerRole !== PeerRole.Host) {
+      return;
+    }
+    const runtime = peerConnection.runtime;
+    if (!runtime || runtime.protocolVersion !== GAME_PROTOCOL_VERSION) {
+      return;
+    }
+    try {
+      runtime.send("spectator/roster", {
+        spectators,
+        issuedAt: Date.now(),
+      });
+    } catch (error) {
+      console.error("Impossible de diffuser la liste des spectateurs.", error);
+    }
+  }, [peerConnection.runtime, resolvedPeerRole, spectators]);
+  useEffect(() => {
+    return () => {
+      if (resolvedPeerRole !== PeerRole.Guest) {
+        return;
+      }
+      const runtime = peerConnection.runtime;
+      if (!runtime || runtime.protocolVersion !== GAME_PROTOCOL_VERSION) {
+        return;
+      }
+      const identity = activeSpectatorIdentityRef.current;
+      if (!identity) {
+        return;
+      }
+      try {
+        runtime.send("spectator/update", {
+          spectator: identity,
+          present: false,
+          issuedAt: Date.now(),
+        });
+      } catch (error) {
+        console.warn("Impossible de notifier le départ du spectateur.", error);
+      }
+    };
+  }, [peerConnection.runtime, resolvedPeerRole]);
+  useEffect(() => {
+    if (resolvedPeerRole !== PeerRole.Host) {
+      return;
+    }
+    if (peerConnection.phase === "connected") {
+      return;
+    }
+    setSpectators((current) => {
+      if (viewAsSpectator && localSpectatorProfile) {
+        const next = addOrUpdateSpectator([], localSpectatorProfile);
+        if (
+          current.length === next.length &&
+          current.every(
+            (entry, index) =>
+              entry.id === next[index]?.id && entry.name === next[index]?.name,
+          )
+        ) {
+          return current;
+        }
+        return next;
+      }
+      if (!viewAsSpectator) {
+        return current.length > 0 ? [] : current;
+      }
+      return current;
+    });
+  }, [
+    resolvedPeerRole,
+    peerConnection.phase,
+    viewAsSpectator,
+    localSpectatorProfile,
+  ]);
   const effectiveLocalPlayerId = viewAsSpectator
     ? null
     : canonicalLocalPlayerId;
@@ -1283,9 +1560,7 @@ export default function RoomPage() {
             player: { id: spectator.id, name: spectator.name },
           },
         });
-        setSpectators((current) =>
-          current.filter((entry) => entry.id !== spectatorId),
-        );
+        setSpectators((current) => removeSpectatorById(current, spectatorId));
       } catch (error) {
         setActionError(
           error instanceof Error
@@ -1371,9 +1646,7 @@ export default function RoomPage() {
       if (!isLocalHost) {
         return;
       }
-      setSpectators((current) =>
-        current.filter((spectator) => spectator.id !== spectatorId),
-      );
+      setSpectators((current) => removeSpectatorById(current, spectatorId));
     },
     [isLocalHost],
   );

--- a/src/components/room/ParticipantsSheet.tsx
+++ b/src/components/room/ParticipantsSheet.tsx
@@ -22,6 +22,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import type { Player, PlayerRole } from "@/lib/game/types";
+import type { SpectatorProfile } from "@/lib/room/spectators";
 import { cn } from "@/lib/utils";
 
 type PlayerSummary = {
@@ -31,10 +32,7 @@ type PlayerSummary = {
   readonly isActive: boolean;
 };
 
-type SpectatorSummary = {
-  readonly id: string;
-  readonly name: string;
-};
+type SpectatorSummary = SpectatorProfile;
 
 type ParticipantsSheetProps = {
   readonly players: readonly PlayerSummary[];

--- a/src/lib/p2p/protocol.ts
+++ b/src/lib/p2p/protocol.ts
@@ -6,10 +6,11 @@ import { PeerRole } from "./peer";
 
 export const GAME_PROTOCOL_NAMESPACE = "keys.game.actions";
 
-export const GAME_PROTOCOL_VERSION = "1.0.0" as const;
+export const GAME_PROTOCOL_VERSION = "1.1.0" as const;
 
 export const SUPPORTED_GAME_PROTOCOL_VERSIONS = [
   GAME_PROTOCOL_VERSION,
+  "1.0.0",
 ] as const;
 
 export type GameProtocolVersion =
@@ -33,8 +34,40 @@ export const gameActionMessageSchema = z
 
 export type GameActionMessagePayload = z.infer<typeof gameActionMessageSchema>;
 
+const spectatorProfileSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1).max(80),
+  })
+  .strict();
+
+const spectatorUpdateMessageSchema = z
+  .object({
+    spectator: spectatorProfileSchema,
+    present: z.boolean(),
+    issuedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export type SpectatorUpdateMessagePayload = z.infer<
+  typeof spectatorUpdateMessageSchema
+>;
+
+const spectatorRosterMessageSchema = z
+  .object({
+    spectators: z.array(spectatorProfileSchema),
+    issuedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export type SpectatorRosterMessagePayload = z.infer<
+  typeof spectatorRosterMessageSchema
+>;
+
 export interface GameProtocolMessageMap {
   "game/action": GameActionMessagePayload;
+  "spectator/update": SpectatorUpdateMessagePayload;
+  "spectator/roster": SpectatorRosterMessagePayload;
 }
 
 export type GameProtocolMessageType = keyof GameProtocolMessageMap;
@@ -51,6 +84,26 @@ export const validateGameActionMessage = (
   payload: unknown,
 ): GameActionMessagePayload => {
   const result = gameActionMessageSchema.safeParse(payload);
+  if (!result.success) {
+    throw result.error;
+  }
+  return result.data;
+};
+
+export const validateSpectatorUpdateMessage = (
+  payload: unknown,
+): SpectatorUpdateMessagePayload => {
+  const result = spectatorUpdateMessageSchema.safeParse(payload);
+  if (!result.success) {
+    throw result.error;
+  }
+  return result.data;
+};
+
+export const validateSpectatorRosterMessage = (
+  payload: unknown,
+): SpectatorRosterMessagePayload => {
+  const result = spectatorRosterMessageSchema.safeParse(payload);
   if (!result.success) {
     throw result.error;
   }

--- a/src/lib/room/spectators.ts
+++ b/src/lib/room/spectators.ts
@@ -1,0 +1,121 @@
+const spectatorCollator = new Intl.Collator("fr", {
+  sensitivity: "base",
+  usage: "sort",
+});
+
+/** Maximum number of characters allowed in a spectator display name. */
+const MAX_SPECTATOR_NAME_LENGTH = 80;
+
+/**
+ * Minimal representation of a spectator used across the room UI and protocol.
+ */
+export interface SpectatorProfile {
+  /** Identifier of the spectator, reused if they promote to player. */
+  id: string;
+  /** Human friendly display name surfaced in the UI. */
+  name: string;
+}
+
+const trimSpectatorId = (candidate: string): string => candidate.trim();
+
+const sliceName = (name: string): string => {
+  if (name.length <= MAX_SPECTATOR_NAME_LENGTH) {
+    return name;
+  }
+  return name.slice(0, MAX_SPECTATOR_NAME_LENGTH);
+};
+
+/**
+ * Generates a stable fallback name derived from the spectator identifier.
+ */
+export const createDefaultSpectatorName = (spectatorId: string): string => {
+  const trimmed = trimSpectatorId(spectatorId);
+  if (!trimmed) {
+    return "Spectateur";
+  }
+  const lastToken = trimmed.split("-").filter(Boolean).pop() ?? trimmed;
+  const suffix = lastToken.slice(-6).toUpperCase();
+  return suffix ? `Spectateur ${suffix}` : "Spectateur";
+};
+
+/**
+ * Normalises the spectator name by trimming whitespace, enforcing a maximum
+ * length and falling back to a deterministic placeholder when empty.
+ */
+export const normaliseSpectatorName = (
+  rawName: string,
+  spectatorId: string,
+): string => {
+  const trimmed = rawName.trim();
+  if (trimmed.length === 0) {
+    return createDefaultSpectatorName(spectatorId);
+  }
+  return sliceName(trimmed);
+};
+
+/**
+ * Creates a new spectator profile with a predictable identifier and name.
+ */
+export const normaliseSpectatorProfile = (
+  candidate: SpectatorProfile,
+): SpectatorProfile => ({
+  id: trimSpectatorId(candidate.id),
+  name: normaliseSpectatorName(candidate.name, candidate.id),
+});
+
+const compareSpectators = (left: SpectatorProfile, right: SpectatorProfile) => {
+  const nameComparison = spectatorCollator.compare(left.name, right.name);
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+  return spectatorCollator.compare(left.id, right.id);
+};
+
+/**
+ * Returns a sorted copy of the provided spectator list.
+ */
+export const sortSpectators = (
+  spectators: readonly SpectatorProfile[],
+): SpectatorProfile[] => [...spectators].sort(compareSpectators);
+
+/**
+ * Upserts a spectator into the list, ensuring normalisation and ordering.
+ */
+export const addOrUpdateSpectator = (
+  spectators: readonly SpectatorProfile[],
+  candidate: SpectatorProfile,
+): SpectatorProfile[] => {
+  const normalised = normaliseSpectatorProfile(candidate);
+  const existingIndex = spectators.findIndex(
+    (spectator) => spectator.id === normalised.id,
+  );
+  if (existingIndex === -1) {
+    return sortSpectators([...spectators, normalised]);
+  }
+  const next = [...spectators];
+  next[existingIndex] = normalised;
+  return sortSpectators(next);
+};
+
+/**
+ * Removes a spectator from the list by identifier.
+ */
+export const removeSpectatorById = (
+  spectators: readonly SpectatorProfile[],
+  spectatorId: string,
+): SpectatorProfile[] =>
+  spectators.filter((spectator) => spectator.id !== spectatorId);
+
+/**
+ * Normalises a roster received over the network before storing it locally.
+ */
+export const normaliseSpectatorRoster = (
+  spectators: readonly SpectatorProfile[],
+): SpectatorProfile[] => {
+  const registry = new Map<string, SpectatorProfile>();
+  spectators.forEach((entry) => {
+    const normalised = normaliseSpectatorProfile(entry);
+    registry.set(normalised.id, normalised);
+  });
+  return sortSpectators(Array.from(registry.values()));
+};


### PR DESCRIPTION
## Summary
- add reusable utilities to normalise and sort spectator profiles
- extend the P2P protocol with spectator update and roster messages (version 1.1.0)
- synchronise spectator presence in the room page and expose the roster to the UI

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a8cbc244832aafba087a21458355