### PR TITLE
Handle duplicate lobby join attempts after match start

### DIFF
--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -127,6 +127,31 @@ describe("reduceGameState", () => {
     );
   });
 
+  it("ignores join actions replayed after the match has started", () => {
+    const playing = createPlayingState();
+    const replayed = reduceGameState(playing, {
+      type: "game/joinLobby",
+      payload: {
+        player: { id: guestId, name: "Guest" },
+      },
+    });
+
+    expect(replayed).toBe(playing);
+  });
+
+  it("prevents new participants from joining once the match has started", () => {
+    const playing = createPlayingState();
+
+    expect(() =>
+      reduceGameState(playing, {
+        type: "game/joinLobby",
+        payload: {
+          player: { id: "late", name: "Late Player" },
+        },
+      }),
+    ).toThrow(InvalidGameActionError);
+  });
+
   it("rejects more than two players in a lobby", () => {
     const lobby = createLobbyState();
     expect(() =>

--- a/src/lib/game/state.ts
+++ b/src/lib/game/state.ts
@@ -172,6 +172,23 @@ export const reduceGameState = (
     }
 
     case "game/joinLobby": {
+      const identity = playerIdentitySchema.parse(action.payload.player);
+
+      if (
+        state.status === GameStatus.Playing ||
+        state.status === GameStatus.Finished
+      ) {
+        const alreadyParticipant = state.players.some(
+          (player) => player.id === identity.id,
+        );
+        assert(
+          alreadyParticipant,
+          action,
+          "Cannot join a match that has already started",
+        );
+        return state;
+      }
+
       const lobbyState = expectState(state, GameStatus.Lobby, action);
       assert(
         lobbyState.players.length < 2,
@@ -179,7 +196,6 @@ export const reduceGameState = (
         "Lobby already has two players",
       );
 
-      const identity = playerIdentitySchema.parse(action.payload.player);
       const alreadyJoined = lobbyState.players.some(
         (player) => player.id === identity.id,
       );


### PR DESCRIPTION
## Summary
- ensure duplicate `game/joinLobby` actions received after the match has started are treated as harmless
- keep the match closed to new players once play has begun and document the behaviour with targeted tests

## Testing
- bun test src/lib/game/state.test.ts
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b50fb8cc832a8754d9ac4a14f4e0