### PR TITLE
Ensure board slots measure scroll dimensions for readiness

### DIFF
--- a/src/components/room/BoardsArea.tsx
+++ b/src/components/room/BoardsArea.tsx
@@ -85,9 +85,13 @@ export function BoardsArea({
       if (!node) {
         return { width: 0, height: 0 } satisfies Size;
       }
+
+      const width = Math.max(node.offsetWidth, node.scrollWidth);
+      const height = Math.max(node.offsetHeight, node.scrollHeight);
+
       return {
-        width: node.offsetWidth,
-        height: node.offsetHeight,
+        width,
+        height,
       } satisfies Size;
     });
   }, [boards.length]);


### PR DESCRIPTION
## Summary
- ensure `BoardsArea` measures each board using the maximum of offset and scroll dimensions so zero-sized slots still expose their natural size

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d24b621c6c832aa98de12d2d4af624