### PR TITLE
Fix overflow of quick action buttons on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,11 +78,14 @@ export default function Home() {
               <Button
                 asChild
                 size="lg"
-                className="group justify-between gap-3"
+                wrapping="wrap"
+                className="group w-full justify-between gap-3 text-left"
                 aria-label={`${action.title} : ${action.buttonLabel}`}
               >
                 <Link href={action.href}>
-                  <span className="text-left">{action.buttonLabel}</span>
+                  <span className="min-w-0 flex-1 text-left">
+                    {action.buttonLabel}
+                  </span>
                   <ArrowRightIcon
                     aria-hidden="true"
                     className="size-4 transition-transform group-hover:translate-x-1"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -26,10 +26,15 @@ const buttonVariants = cva(
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
+      wrapping: {
+        nowrap: "whitespace-nowrap shrink-0",
+        wrap: "whitespace-normal",
+      },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
+      wrapping: "nowrap",
     },
   },
 );
@@ -38,6 +43,7 @@ function Button({
   className,
   variant,
   size,
+  wrapping,
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
@@ -49,7 +55,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant, size, wrapping, className }))}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- add a wrapping variant to the shared Button component so long labels can break lines
- use the new variant on the home page quick actions and ensure the text flexes within the button

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d27ea6c5bc832ab58912356cfb7517