### PR TITLE
feat: highlight active turns and surface both boards

### DIFF
--- a/src/components/room/ActiveTurnNotice.tsx
+++ b/src/components/room/ActiveTurnNotice.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { TimerIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ActiveTurnNoticeProps {
+  readonly title: string;
+  readonly description: string;
+  readonly className?: string;
+  readonly action?: ReactNode;
+}
+
+/**
+ * Displays a prominent notice summarising whose turn is currently active.
+ *
+ * The component is optimised for live gameplay feedback: it announces updates
+ * via `aria-live` so that assistive technologies and spectators immediately
+ * perceive turn changes while keeping both boards visible on screen.
+ */
+export function ActiveTurnNotice({
+  title,
+  description,
+  className,
+  action = null,
+}: ActiveTurnNoticeProps) {
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className={cn(
+        "flex flex-col gap-2 rounded-3xl border border-primary/40 bg-primary/10 px-4 py-3 text-primary shadow-sm backdrop-blur supports-[backdrop-filter]:bg-primary/15",
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2 text-sm font-semibold">
+        <TimerIcon aria-hidden className="size-4" />
+        <span>{title}</span>
+      </div>
+      <p className="text-xs text-primary/80 sm:text-sm">{description}</p>
+      {action}
+    </div>
+  );
+}

--- a/src/components/room/PlayerBoard.tsx
+++ b/src/components/room/PlayerBoard.tsx
@@ -73,6 +73,31 @@ export function PlayerBoard({
     : "none";
   const hiddenCount = hiddenCardIds.size;
 
+  const activeTurnBadgeLabel = isActiveTurn
+    ? isLocal
+      ? "À vous de jouer"
+      : isSpectatorView
+        ? `Tour de ${player.name}`
+        : "Tour de l’adversaire"
+    : null;
+
+  let playingStatusMessage: string | null = null;
+  if (status === GameStatus.Playing) {
+    if (isActiveTurn) {
+      playingStatusMessage = isLocal
+        ? "C’est à vous de jouer : masquez les cartes correspondantes ou annoncez une proposition."
+        : isSpectatorView
+          ? `Tour de ${player.name} — observez ses actions en direct.`
+          : "Tour de votre adversaire : observez ses actions avant votre prochain tour.";
+    } else {
+      playingStatusMessage = isLocal
+        ? "Tour de l’adversaire : observez son plateau pour préparer votre réponse."
+        : isSpectatorView
+          ? `En attente du prochain mouvement de ${player.name}.`
+          : "Tour en cours : suivez les manipulations de votre adversaire.";
+    }
+  }
+
   let secretContent: React.ReactNode;
   if (secretCard && showSecretCard) {
     secretContent = <SecretCardPreview card={secretCard} />;
@@ -102,9 +127,13 @@ export function PlayerBoard({
   return (
     <Card
       className={cn(
-        "flex h-full min-h-0 flex-col border-2 shadow-sm transition-colors",
+        "flex h-full min-h-0 flex-col border-2 transition-colors transition-shadow",
         accentClasses[accent],
+        isActiveTurn
+          ? "shadow-lg ring-2 ring-primary/60 ring-offset-2 ring-offset-background"
+          : "shadow-sm ring-1 ring-transparent ring-offset-2 ring-offset-background",
       )}
+      data-active-turn={isActiveTurn ? "true" : "false"}
     >
       <CardHeader className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -135,10 +164,10 @@ export function PlayerBoard({
                 À préparer
               </Badge>
             )}
-            {isActiveTurn ? (
+            {activeTurnBadgeLabel ? (
               <Badge className="flex items-center gap-1 bg-primary/15 text-primary">
                 <TimerIcon aria-hidden className="size-3.5" />
-                Tour en cours
+                {activeTurnBadgeLabel}
               </Badge>
             ) : null}
           </div>
@@ -168,21 +197,17 @@ export function PlayerBoard({
         </div>
 
         <div className="flex flex-1 min-h-0 flex-col space-y-3">
-          <div className="flex flex-wrap items-center justify-between text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:justify-between">
             <span>
               {hiddenCount} carte{hiddenCount > 1 ? "s" : ""} masquée
               {hiddenCount > 1 ? "s" : ""}
             </span>
-            {status === GameStatus.Playing ? (
-              <span>
-                {isActiveTurn
-                  ? "Vous pouvez manipuler vos cartes pendant ce tour."
-                  : isLocal
-                    ? "Tour de l’adversaire."
-                    : "Tour en cours."}
-              </span>
-            ) : null}
           </div>
+          {playingStatusMessage ? (
+            <p className="text-sm font-medium text-foreground">
+              {playingStatusMessage}
+            </p>
+          ) : null}
           <div className="min-h-0 flex-1 overflow-hidden">
             <ul
               className="grid h-full list-none gap-2 overflow-hidden pr-1 sm:gap-3"


### PR DESCRIPTION
## Summary
- add an `ActiveTurnNotice` banner so everyone sees whose turn is active while keeping both grids visible
- compute contextual turn copy in the room page and expose both boards with an accessible heading for spectators
- highlight the active board with clearer messaging and styling cues on each player grid

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d27ec6ac1c832a903f460b30a76970