### PR TITLE
feat: support removing players from rooms

### DIFF
--- a/src/components/room/ParticipantsSheet.tsx
+++ b/src/components/room/ParticipantsSheet.tsx
@@ -65,6 +65,11 @@ function PlayerRow({
   onKick?: (playerId: string) => void;
 }) {
   const { player, ready, isLocal, isActive } = summary;
+  const canShowKickButton =
+    isHost &&
+    canKick &&
+    typeof onKick === "function" &&
+    player.role !== PlayerRole.Host;
   const badgeItems = [
     ready
       ? {
@@ -119,7 +124,7 @@ function PlayerRow({
             </p>
           </div>
         </div>
-        {isHost && canKick && onKick ? (
+        {canShowKickButton ? (
           <Button
             type="button"
             variant="outline"

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -193,6 +193,13 @@ export type ResetAction = {
   type: "game/reset";
 };
 
+export type LeaveGameAction = {
+  type: "game/leave";
+  payload: {
+    playerId: string;
+  };
+};
+
 export type Action =
   | CreateLobbyAction
   | JoinLobbyAction
@@ -202,7 +209,8 @@ export type Action =
   | FlipCardAction
   | EndTurnAction
   | GuessAction
-  | ResetAction;
+  | ResetAction
+  | LeaveGameAction;
 
 /**
  * Actions that are synchronised through the peer-to-peer channel after the
@@ -213,7 +221,8 @@ export type SynchronisedAction =
   | Extract<Action, { type: "turn/flipCard" }>
   | Extract<Action, { type: "turn/end" }>
   | Extract<Action, { type: "turn/guess" }>
-  | Extract<Action, { type: "game/reset" }>;
+  | Extract<Action, { type: "game/reset" }>
+  | Extract<Action, { type: "game/leave" }>;
 
 /**
  * Snapshot sent by the host to initialise or resynchronise the guest state.


### PR DESCRIPTION
## Summary
- add a `game/leave` action to the game domain model and schemas
- handle lobby, match, and finished departures in the reducer with tests
- propagate leave events through the P2P runtime and surface them in the room UI

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d287fd288c832ab5f362938a3c6709