### PR TITLE
feat: allow restarting matches from the host UI

### DIFF
--- a/src/components/room/FinalResultCard.tsx
+++ b/src/components/room/FinalResultCard.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { RotateCcwIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -15,9 +18,16 @@ import { getConclusionLabel } from "./roomLabels";
 interface FinalResultCardProps {
   state: Extract<GameState, { status: "finished" }>;
   cardLookup: Map<string, GameCard>;
+  onRestartMatch?: () => void;
+  restartDisabled?: boolean;
 }
 
-export function FinalResultCard({ state, cardLookup }: FinalResultCardProps) {
+export function FinalResultCard({
+  state,
+  cardLookup,
+  onRestartMatch,
+  restartDisabled = false,
+}: FinalResultCardProps) {
   const winner = selectWinner(state);
   const guess = state.finalGuess;
   const guessedCard = cardLookup.get(guess.cardId);
@@ -34,7 +44,7 @@ export function FinalResultCard({ state, cardLookup }: FinalResultCardProps) {
         </CardTitle>
         <CardDescription>{getConclusionLabel(state.reason)}</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2 text-sm">
+      <CardContent className="space-y-3 text-sm">
         <p className="text-foreground">
           {guesser ? guesser.name : "Un joueur"} a tenté de deviner{" "}
           {guessedCard ? guessedCard.label : guess.cardId} chez{" "}
@@ -44,6 +54,17 @@ export function FinalResultCard({ state, cardLookup }: FinalResultCardProps) {
           Tour {state.turn} —{" "}
           {guess.correct ? "réponse correcte." : "réponse incorrecte."}
         </p>
+        {onRestartMatch ? (
+          <Button
+            type="button"
+            onClick={onRestartMatch}
+            disabled={restartDisabled}
+            className="w-full sm:w-auto"
+          >
+            <RotateCcwIcon aria-hidden className="mr-2 size-4" />
+            Relancer une manche
+          </Button>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/src/components/room/TurnBar.tsx
+++ b/src/components/room/TurnBar.tsx
@@ -17,8 +17,8 @@ type HostControlConfig = {
   readonly nextTurnDisabled: boolean;
   readonly onPause?: () => void;
   readonly pauseDisabled: boolean;
-  readonly onResetRound?: () => void;
-  readonly resetDisabled: boolean;
+  readonly onRestartMatch?: () => void;
+  readonly restartDisabled: boolean;
 };
 
 type GuessFailureSummary = {
@@ -82,8 +82,8 @@ function TurnBar({
     nextTurnDisabled,
     onPause,
     pauseDisabled,
-    onResetRound,
-    resetDisabled,
+    onRestartMatch,
+    restartDisabled,
   } = hostControls;
 
   const turnSummary = formatTurnSummary(turn, activePlayerName, status);
@@ -133,15 +133,17 @@ function TurnBar({
                   <PauseIcon aria-hidden className="mr-2 size-4" />
                   Pause
                 </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onResetRound}
-                  disabled={resetDisabled || !onResetRound}
-                >
-                  <RotateCcwIcon aria-hidden className="mr-2 size-4" />
-                  Réinitialiser
-                </Button>
+                {onRestartMatch ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={onRestartMatch}
+                    disabled={restartDisabled}
+                  >
+                    <RotateCcwIcon aria-hidden className="mr-2 size-4" />
+                    Relancer une manche
+                  </Button>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/lib/game/schema.ts
+++ b/src/lib/game/schema.ts
@@ -301,6 +301,12 @@ export const resetActionSchema = z
   })
   .strict();
 
+export const restartActionSchema = z
+  .object({
+    type: z.literal<"game/restart">("game/restart"),
+  })
+  .strict();
+
 export const leaveActionSchema = z
   .object({
     type: z.literal<"game/leave">("game/leave"),
@@ -316,6 +322,7 @@ export const synchronisedActionSchema = z.discriminatedUnion("type", [
   endTurnActionSchema,
   guessActionSchema,
   resetActionSchema,
+  restartActionSchema,
   leaveActionSchema,
 ]);
 
@@ -329,6 +336,7 @@ export const actionSchema: z.ZodType<Action> = z.discriminatedUnion("type", [
   endTurnActionSchema,
   guessActionSchema,
   resetActionSchema,
+  restartActionSchema,
   leaveActionSchema,
 ]);
 

--- a/src/lib/game/state.test.ts
+++ b/src/lib/game/state.test.ts
@@ -524,6 +524,40 @@ describe("reduceGameState", () => {
     });
   });
 
+  it("restarts an ongoing match and keeps only the host in the lobby", () => {
+    const playing = createPlayingState();
+
+    const restarted = reduceGameState(playing, { type: "game/restart" });
+
+    expect(restarted.status).toBe(GameStatus.Lobby);
+    expect(restarted.grid).toBe(playing.grid);
+    expect(restarted.players).toHaveLength(1);
+    expect(restarted.players[0]).toMatchObject({
+      id: hostId,
+      role: PlayerRole.Host,
+      secretCardId: undefined,
+      flippedCardIds: [],
+    });
+  });
+
+  it("restarts a finished match and clears all previous turn data", () => {
+    const playing = createPlayingState();
+    const finished = reduceGameState(playing, {
+      type: "turn/guess",
+      payload: { playerId: hostId, targetPlayerId: guestId, cardId: "card-d" },
+    });
+
+    const restarted = reduceGameState(finished, { type: "game/restart" });
+
+    expect(restarted.status).toBe(GameStatus.Lobby);
+    expect(restarted.players).toHaveLength(1);
+    expect(restarted.players[0]).toMatchObject({
+      id: hostId,
+      secretCardId: undefined,
+      flippedCardIds: [],
+    });
+  });
+
   it("resets back to the idle state", () => {
     const playing = createPlayingState();
     const finished = reduceGameState(playing, {

--- a/src/lib/game/types.ts
+++ b/src/lib/game/types.ts
@@ -193,6 +193,10 @@ export type ResetAction = {
   type: "game/reset";
 };
 
+export type RestartAction = {
+  type: "game/restart";
+};
+
 export type LeaveGameAction = {
   type: "game/leave";
   payload: {
@@ -210,6 +214,7 @@ export type Action =
   | EndTurnAction
   | GuessAction
   | ResetAction
+  | RestartAction
   | LeaveGameAction;
 
 /**
@@ -222,6 +227,7 @@ export type SynchronisedAction =
   | Extract<Action, { type: "turn/end" }>
   | Extract<Action, { type: "turn/guess" }>
   | Extract<Action, { type: "game/reset" }>
+  | Extract<Action, { type: "game/restart" }>
   | Extract<Action, { type: "game/leave" }>;
 
 /**


### PR DESCRIPTION
## Summary
- add a dedicated `game/restart` action that brings the reducer back to a clean lobby with the existing host
- wire the room page to reset local flags when restarting and expose the action through the turn bar and final result card
- extend reducer and replicator tests to cover the restart flow

## Testing
- bun test
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2907700c0832a8672b07f8291ae7f