### PR TITLE
Fix secret selection modal when rejoining active match

### DIFF
--- a/src/app/room/[roomId]/page.tsx
+++ b/src/app/room/[roomId]/page.tsx
@@ -1312,17 +1312,28 @@ export default function RoomPage() {
 
     const needsSecretSelection =
       gameState.status === GameStatus.Lobby && !localPlayer.secretCardId;
+    const wasPromptedAutomatically = hasPromptedSecretSelection;
 
     if (needsSecretSelection) {
-      if (!hasPromptedSecretSelection) {
+      if (!wasPromptedAutomatically) {
         setSecretSelectionPlayerId((current) => current ?? localPlayer.id);
         setHasPromptedSecretSelection(true);
       }
       return;
     }
 
-    if (hasPromptedSecretSelection) {
+    if (wasPromptedAutomatically) {
       setHasPromptedSecretSelection(false);
+    }
+
+    const shouldCloseSecretSelection =
+      secretSelectionPlayerId !== null &&
+      (gameState.status !== GameStatus.Lobby ||
+        (wasPromptedAutomatically &&
+          secretSelectionPlayerId === localPlayer.id));
+
+    if (shouldCloseSecretSelection) {
+      setSecretSelectionPlayerId(null);
     }
   }, [
     gameState.status,


### PR DESCRIPTION
## Summary
- reset the automatic secret-selection prompt once the player no longer needs to pick a card
- close any lingering secret-selection modal when the match has already started to avoid invalid state updates

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68d296988094832aafa2234111538325