### PR TITLE
Add snapshot synchronization handling for peer connections

### DIFF
--- a/src/lib/p2p/action-sync.test.ts
+++ b/src/lib/p2p/action-sync.test.ts
@@ -155,6 +155,7 @@ describe("createActionReplicator", () => {
       issuerPeerId: "peer-guest",
       issuerRole: PeerRole.Guest,
       acknowledgedByHost: false,
+      issuedAt: 1,
     };
 
     const firstResult = hostReplicator.handleRemote(joinPayload);

--- a/src/lib/p2p/action-sync.ts
+++ b/src/lib/p2p/action-sync.ts
@@ -115,6 +115,7 @@ export const createActionReplicator = (
       issuerPeerId: options.localPeerId,
       issuerRole: options.role,
       acknowledgedByHost,
+      issuedAt: Date.now(),
     };
 
     try {

--- a/src/lib/p2p/remote-action-queue.test.ts
+++ b/src/lib/p2p/remote-action-queue.test.ts
@@ -10,6 +10,7 @@ const createPayload = (suffix: string): GameActionMessagePayload => ({
   issuerPeerId: `peer-${suffix}`,
   issuerRole: PeerRole.Host,
   acknowledgedByHost: true,
+  issuedAt: Number(suffix),
 });
 
 describe("RemoteActionQueue", () => {


### PR DESCRIPTION
## Summary
- extend the P2P protocol with snapshot and acknowledgement envelopes plus action timestamps
- have the room runtime emit snapshots from the host and apply them on guests before replaying buffered actions
- update the action replicator and queue tests to cover the enriched payload shape

## Testing
- bun run lint
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d2a08916a8832a8b36a4ff8cdbe9df